### PR TITLE
addr matched to tiger street but no range returns closest range

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: addr
-Title: Clean, Parse, Harmonize, and Hash Messy Real-World Addresses
+Title: Clean, Parse, Harmonize, Match, and Geocode Messy Real-World Addresses
 Version: 0.4.0.9010
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: addr
 Title: Clean, Parse, Harmonize, and Hash Messy Real-World Addresses
-Version: 0.4.0.9000
+Version: 0.4.0.9010
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0289-3151"))

--- a/R/addr_geocode.R
+++ b/R/addr_geocode.R
@@ -6,7 +6,7 @@
 #' and is recorded in the `match_method` column of the returned tibble:  
 #' 1. `ref_addr`: reference s2 cell from direct match to reference address
 #' 2. `tiger_range`: centroid of street-matched TIGER address ranges containing street number
-#' 3. `tiger_street`: centroid of street-matched TIGER address ranges for entire street if no containing ranges
+#' 3. `tiger_street`: centroid of street-matched TIGER address ranges closest to the street number
 #' 4. `none`: unmatched using all previous approaches; return missing s2 cell identifier
 #'
 #' @param x an addr vector (or character vector of address strings) to geocode
@@ -76,7 +76,7 @@ addr_match_geocode <- function(x,
       x_addr[x_addr_ref_no_match_which],
       county = county,
       year = year,
-      street_only_match = FALSE,
+      street_only_match = "none",
       summarize = "centroid"
     ) |>
     purrr::discard(\(.) length(.) < 1) |> # removes NULL
@@ -93,7 +93,7 @@ addr_match_geocode <- function(x,
       x_addr[x_addr_ref_no_no_match_which],
       county = county,
       year = year,
-      street_only_match = TRUE,
+      street_only_match = "closest",
       summarize = "centroid"
     ) |>
     purrr::discard(\(.) length(.) < 1) |> # removes NULL

--- a/R/addr_tiger_match.R
+++ b/R/addr_tiger_match.R
@@ -46,9 +46,9 @@ get_tiger_street_ranges <- function(county, year = "2022") {
 #' @param x an addr vector to match
 #' @param county character string of county identifier
 #' @param year year of tigris product
+#' @param street_only_match for addresses that match a TIGER street name, but have street numbers that don't
+#' intersect with ranges of potential street numbers, return `"none"`, `"all"`, or the `"closest"` range geographies
 #' @param summarize optionally summarize matched street ranges as their union or centroid
-#' @param street_only_match logical; consider an addr that matches on street name,
-#' but does not have a street number within the listed ranges a match?
 #' @return a list of matched tigris street range tibbles;
 #' a NULL value indicates that no street name was matched; if `street_only_match` is FALSE,
 #' a street range tibble with zero rows indicates that although a street was matched,
@@ -67,9 +67,10 @@ get_tiger_street_ranges <- function(county, year = "2022") {
 addr_match_tiger_street_ranges <- function(x,
                                            county = "39061",
                                            year = "2022",
-                                           street_only_match = TRUE,
+                                           street_only_match = c("none", "all", "closest"),
                                            summarize = c("none", "union", "centroid")) {
   stopifnot(inherits(x, "addr"))
+  street_only_match <- rlang::arg_match(street_only_match)
   summarize <- rlang::arg_match(summarize)
   ia <- unique(x)
   d_tiger <- get_tiger_street_ranges(county = county, year = year)
@@ -96,8 +97,12 @@ addr_match_tiger_street_ranges <- function(x,
       vctrs::field(ia, "street_number"), street_matches,
       \(.sn, .sm) {
         out <- dplyr::filter(.sm, from <= .sn, to >= .sn)
-        if (nrow(out) == 0 & street_only_match) {
-          return(.sm)
+        if (nrow(out) == 0) {
+          if (street_only_match == "none") return(out)
+          if (street_only_match == "all") return(.sm)
+          if (street_only_match == "closest") {
+            return(.sm[unique(which.min(abs(.sm$from - .sn)), which.min(abs(.sm$to - .sn))), ])
+          }
         }
         return(out)
       }

--- a/R/addr_tiger_match.R
+++ b/R/addr_tiger_match.R
@@ -57,11 +57,12 @@ get_tiger_street_ranges <- function(county, year = "2022") {
 #' @examples
 #' my_addr <- as_addr(c("224 Woolper Ave", "3333 Burnet Ave", "33333 Burnet Ave", "609 Walnut St"))
 #' 
-#' addr_match_tiger_street_ranges(my_addr, county = "39061", street_only_match = FALSE)
+#' addr_match_tiger_street_ranges(my_addr, county = "39061", street_only_match = "all")
 #' 
 #' addr_match_tiger_street_ranges(my_addr, county = "39061", summarize = "centroid")
 #'
-#' addr_match_tiger_street_ranges(my_addr, county = "39061", summarize = "centroid") |>
+#' addr_match_tiger_street_ranges(my_addr, county = "39061",
+#'                                street_only_match = "closest", summarize = "centroid") |>
 #'   dplyr::bind_rows() |>
 #'   dplyr::mutate(census_bg_id = s2_join_tiger_bg(s2::as_s2_cell(s2_geography)))
 addr_match_tiger_street_ranges <- function(x,

--- a/man/addr_match_geocode.Rd
+++ b/man/addr_match_geocode.Rd
@@ -36,7 +36,7 @@ and is recorded in the \code{match_method} column of the returned tibble:
 \enumerate{
 \item \code{ref_addr}: reference s2 cell from direct match to reference address
 \item \code{tiger_range}: centroid of street-matched TIGER address ranges containing street number
-\item \code{tiger_street}: centroid of street-matched TIGER address ranges for entire street if no containing ranges
+\item \code{tiger_street}: centroid of street-matched TIGER address ranges closest to the street number
 \item \code{none}: unmatched using all previous approaches; return missing s2 cell identifier
 }
 }

--- a/man/addr_match_tiger_street_ranges.Rd
+++ b/man/addr_match_tiger_street_ranges.Rd
@@ -8,7 +8,7 @@ addr_match_tiger_street_ranges(
   x,
   county = "39061",
   year = "2022",
-  street_only_match = TRUE,
+  street_only_match = c("none", "all", "closest"),
   summarize = c("none", "union", "centroid")
 )
 }
@@ -19,8 +19,8 @@ addr_match_tiger_street_ranges(
 
 \item{year}{year of tigris product}
 
-\item{street_only_match}{logical; consider an addr that matches on street name,
-but does not have a street number within the listed ranges a match?}
+\item{street_only_match}{for addresses that match a TIGER street name, but have street numbers that don't
+intersect with ranges of potential street numbers, return \code{"none"}, \code{"all"}, or the \code{"closest"} range geographies}
 
 \item{summarize}{optionally summarize matched street ranges as their union or centroid}
 }

--- a/man/addr_match_tiger_street_ranges.Rd
+++ b/man/addr_match_tiger_street_ranges.Rd
@@ -36,11 +36,12 @@ Match an addr vector to TIGER street ranges
 \examples{
 my_addr <- as_addr(c("224 Woolper Ave", "3333 Burnet Ave", "33333 Burnet Ave", "609 Walnut St"))
 
-addr_match_tiger_street_ranges(my_addr, county = "39061", street_only_match = FALSE)
+addr_match_tiger_street_ranges(my_addr, county = "39061", street_only_match = "all")
 
 addr_match_tiger_street_ranges(my_addr, county = "39061", summarize = "centroid")
 
-addr_match_tiger_street_ranges(my_addr, county = "39061", summarize = "centroid") |>
+addr_match_tiger_street_ranges(my_addr, county = "39061",
+                               street_only_match = "closest", summarize = "centroid") |>
   dplyr::bind_rows() |>
   dplyr::mutate(census_bg_id = s2_join_tiger_bg(s2::as_s2_cell(s2_geography)))
 }

--- a/tests/testthat/test-addr_match_geocode.R
+++ b/tests/testthat/test-addr_match_geocode.R
@@ -1,6 +1,5 @@
 test_that("addr_match_geocode() works", {
   skip_if(testthat:::on_ci() && Sys.info()[["sysname"]] == "Linux", "Skipping test on CI on Linux")
-  set.seed(100)
   cagis_s2 <-
     cagis_addr()$cagis_addr_data |>
     purrr::modify_if(\(.) length(.) > 0 && nrow(.) > 1, dplyr::slice_sample, n = 1) |>

--- a/tests/testthat/test-addr_tiger_match.R
+++ b/tests/testthat/test-addr_tiger_match.R
@@ -8,13 +8,11 @@ test_that("get_tiger_street_ranges() works", {
     expect_s3_class(c("tbl_df")) |>
     nrow() |>
     expect_identical(4L)
-
 })
 
 test_that("addr_match_tiger_street_ranges() works", {
-
   addr_match_tiger_street_ranges(as_addr(c("224 Woolper Ave", "3333 Burnet Ave", "33333 Burnet Ave", "609 Walnut St")),
-    street_only_match = FALSE
+    street_only_match = "none"
   ) |>
     purrr::map(nrow) |>
     expect_identical(list(
@@ -23,9 +21,9 @@ test_that("addr_match_tiger_street_ranges() works", {
       `33333 Burnet Avenue` = 0L,
       `609 Walnut Street` = NULL
     ))
-                                 
+
   addr_match_tiger_street_ranges(as_addr(c("224 Woolper Ave", "3333 Burnet Ave", "33333 Burnet Ave", "609 Walnut St")),
-    street_only_match = TRUE
+    street_only_match = "all"
   ) |>
     purrr::map(nrow) |>
     expect_identical(list(
@@ -35,4 +33,14 @@ test_that("addr_match_tiger_street_ranges() works", {
       `609 Walnut Street` = NULL
     ))
 
+  addr_match_tiger_street_ranges(as_addr(c("224 Woolper Ave", "3333 Burnet Ave", "33333 Burnet Ave", "609 Walnut St")),
+    street_only_match = "closest"
+  ) |>
+    purrr::map(nrow) |>
+    expect_identical(list(
+      `224 Woolper Avenue` = 1L,
+      `3333 Burnet Avenue` = 2L,
+      `33333 Burnet Avenue` = 1L,
+      `609 Walnut Street` = NULL
+    ))
 })


### PR DESCRIPTION
- expanded argument for street-only matching methods when matching tiger ranges
- new default behavior for addr_match_geocode (instead of returning _all_ ranges in this case)