### PR TITLE
suppress extra offset for tiger offset ranges

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -675,7 +675,23 @@ geocode_zip <- function(
         fraction
       )
       # TIGER side is relative to the digitized street line direction.
-      geocode_offset_point(point, brm$s2_geography, fraction, brm$side, offset)
+      range_offset <- if (
+        "OFFSET" %in% names(brm) &&
+          length(brm$OFFSET) == 1L &&
+          !is.na(brm$OFFSET) &&
+          brm$OFFSET == "Y"
+      ) {
+        0
+      } else {
+        offset
+      }
+      geocode_offset_point(
+        point,
+        brm$s2_geography,
+        fraction,
+        brm$side,
+        range_offset
+      )
     }) |>
     do.call(c, args = _)
 

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -578,6 +578,55 @@ test_that("geocode_zip offsets matched points by TIGER side", {
   )
 })
 
+test_that("geocode_zip suppresses default offset for TIGER offset ranges", {
+  local_mocked_bindings(
+    taf_zip = function(zipcode, map = TRUE, ...) {
+      tibble::tibble(
+        ZIP = rep("45219", 2),
+        addr_street = addr_street(
+          predirectional = c("", ""),
+          premodifier = c("", ""),
+          pretype = c("", ""),
+          name = c("Main", "Main"),
+          posttype = c("St", "St"),
+          postdirectional = c("", "")
+        ),
+        side = c("L", "R"),
+        FROMHN = c(1L, 2L),
+        TOHN = c(99L, 100L),
+        PARITY = c("O", "E"),
+        OFFSET = c("Y", "N"),
+        s2_geography = s2::as_s2_geography(
+          rep("LINESTRING (0 0, 0.01 0)", 2)
+        )
+      )
+    },
+    match_addr_street = function(x, y, ...) {
+      y[rep(1L, length(x))]
+    }
+  )
+
+  x <- addr(
+    addr_number(digits = c("1", "2")),
+    addr_street(name = c("Main", "Main"), posttype = c("St", "St")),
+    addr_place(zipcode = c("45219", "45219"))
+  )
+
+  on_line <- geocode_zip(x, offset = 0, taf_install = FALSE, taf_check = FALSE)
+  offset <- geocode_zip(x, offset = 10, taf_install = FALSE, taf_check = FALSE)
+
+  expect_equal(s2::s2_y(offset$matched_geography[1]), 0, tolerance = 1e-8)
+  expect_lt(s2::s2_y(offset$matched_geography[2]), 0)
+  expect_equal(
+    as.numeric(s2::s2_distance(
+      on_line$matched_geography,
+      offset$matched_geography
+    )),
+    c(0, 10),
+    tolerance = 1e-5
+  )
+})
+
 test_that("geocode_zip ignores matched TAF ranges with missing endpoints", {
   local_mocked_bindings(
     taf_zip = function(zipcode, map = TRUE, ...) {


### PR DESCRIPTION
skip the default perpendicular geocode offset when the selected TIGER range has `OFFSET == "Y"`