### PR TITLE
improve geocode error context

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 ^LICENSE\.md$
+^\.git$
 ^src/\.cargo$
 ^\.github$
 ^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: addr
 Title: Clean, Parse, Harmonize, Match, and Geocode Messy Real-World US Addresses
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: 
     c(person("Cole", "Brokamp", email = "cole@colebrokamp.com", role = c("aut", "cre")),
       person("Erika", "Manning", role = c("aut")))

--- a/R/addr_helpers.R
+++ b/R/addr_helpers.R
@@ -9,6 +9,39 @@ is_zip5 <- function(x) {
   is.character(x) && length(x) == 1 && grepl("^[0-9]{5}$", x)
 }
 
+is_valid_zipcode <- function(x) {
+  out <- rep(FALSE, length(x))
+  present <- !is.na(x) & x != ""
+  out[present] <- grepl("^[0-9]{5}$", x[present]) &
+    !grepl("^000", x[present])
+  out
+}
+
+is_invalid_zipcode <- function(x) {
+  !is.na(x) & x != "" & !is_valid_zipcode(x)
+}
+
+addr_problem_examples <- function(x, i, n = 5L, width = 120L) {
+  i <- i[!is.na(i)]
+  if (length(i) == 0L) {
+    return("")
+  }
+  i_show <- utils::head(i, n)
+  values <- as.character(x[i_show])
+  values[is.na(values)] <- "<NA>"
+  values <- gsub("[\r\n\t]+", " ", values)
+  long <- nchar(values, type = "width") > width
+  values[long] <- paste0(substr(values[long], 1L, width - 3L), "...")
+  out <- paste(
+    sprintf("%s: %s", i_show, encodeString(values, quote = "\"")),
+    collapse = ", "
+  )
+  if (length(i) > n) {
+    out <- paste0(out, ", ... and ", length(i) - n, " more")
+  }
+  out
+}
+
 recycle_fields <- function(fields, class_name) {
   lens <- vapply(fields, length, integer(1))
   target <- max(lens, 0L)

--- a/R/addr_part.R
+++ b/R/addr_part.R
@@ -281,10 +281,7 @@ addr_place <- S7::new_class(
     if (!is.null(len_msg)) {
       return(len_msg)
     }
-    bad <- !is.na(self@zipcode) &
-      self@zipcode != "" &
-      !grepl("^[0-9]{5}$", self@zipcode) |
-      grepl("^000", self@zipcode)
+    bad <- is_invalid_zipcode(self@zipcode)
     if (any(bad)) {
       "@zipcode must be exactly five numeric digits and not lead with three zeros"
     }

--- a/R/addr_part_match.R
+++ b/R/addr_part_match.R
@@ -940,6 +940,6 @@ zipcode_variant <- function(
   )
   result <- lapply(variant, \(.) variant_fns[[.]](strsplit(x, "")[[1]]))
   uout <- unique(do.call(c, result))
-  out <- as.character(as.integer(uout[uout != x]))
-  sprintf("%05s", out)
+  out <- sprintf("%05d", as.integer(uout[uout != x]))
+  out[is_valid_zipcode(out)]
 }

--- a/R/as_addr.R
+++ b/R/as_addr.R
@@ -183,22 +183,24 @@ S7::method(as_addr, S7::class_character) <- function(
       "Truncating ",
       length(bad_zips),
       " parsed ZIP codes to the first five characters.",
+      " Affected address examples: ",
+      addr_problem_examples(x, bad_zips),
+      ".",
       call. = FALSE
     )
     place_zip[bad_zips] <- substr(place_zip[bad_zips], 1, 5)
   }
 
-  malformed_zips <- which(
-    !is.na(place_zip) &
-      place_zip != "" &
-      (!grepl("^[0-9]{5}$", place_zip) | grepl("^000", place_zip))
-  )
+  malformed_zips <- which(is_invalid_zipcode(place_zip))
 
   if (length(malformed_zips) > 0) {
     warning(
       "Setting ",
       length(malformed_zips),
       " malformed parsed ZIP codes to missing.",
+      " Affected address examples: ",
+      addr_problem_examples(x, malformed_zips),
+      ".",
       call. = FALSE
     )
     place_zip[malformed_zips] <- NA_character_

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -180,7 +180,7 @@ geocode_map <- function(x, FUN, progress, ...) {
   if (progress) {
     return(lapply_pb(x, FUN, ...))
   }
-  lapply(x, FUN, ...)
+  lapply(x, function(.x) geocode_call_with_context(.x, FUN, ...))
 }
 
 geocode_use_mirai <- function() {
@@ -246,7 +246,17 @@ geocode_worker <- function(
   }
   ns <- loadNamespace("addr")
   geocode_zip_fn <- get("geocode_zip", envir = ns, inherits = FALSE)
-  out <- do.call(geocode_zip_fn, c(list(x), geocode_args))
+  context_message_fn <- get(
+    "geocode_context_error_message",
+    envir = ns,
+    inherits = FALSE
+  )
+  out <- tryCatch(
+    do.call(geocode_zip_fn, c(list(x), geocode_args)),
+    error = function(cnd) {
+      stop(context_message_fn(x, cnd), call. = FALSE)
+    }
+  )
   out$matched_geography <- s2::s2_as_text(out$matched_geography)
   out
 }
@@ -271,6 +281,40 @@ geocode_check_parallel_results <- function(x) {
 geocode_restore_parallel_result <- function(x) {
   x$matched_geography <- s2::as_s2_geography(x$matched_geography)
   x
+}
+
+geocode_call_with_context <- function(x, FUN, ...) {
+  tryCatch(
+    FUN(x, ...),
+    error = function(cnd) {
+      stop(geocode_context_error_message(x, cnd), call. = FALSE)
+    }
+  )
+}
+
+geocode_context_error_message <- function(x, cnd) {
+  zip <- unique(x@place@zipcode)
+  zip <- zip[!is.na(zip) & zip != ""]
+  zip <- if (length(zip) == 0L) {
+    "<missing>"
+  } else {
+    paste(zip, collapse = ", ")
+  }
+  n_addr <- length(x)
+  noun <- if (n_addr == 1L) "address" else "addresses"
+  examples <- addr_problem_examples(format(x), seq_along(x))
+  paste0(
+    "geocoding failed for ZIP ",
+    zip,
+    " (",
+    n_addr,
+    " input ",
+    noun,
+    "). Affected address examples: ",
+    examples,
+    ". Original error: ",
+    conditionMessage(cnd)
+  )
 }
 
 lapply_pb <- function(x, FUN, ...) {
@@ -302,7 +346,12 @@ lapply_pb <- function(x, FUN, ...) {
     if ("progress_callback" %in% names(formals(FUN))) {
       args$progress_callback <- progress_callback
     }
-    out[[i]] <- do.call(FUN, args)
+    out[[i]] <- tryCatch(
+      do.call(FUN, args),
+      error = function(cnd) {
+        stop(geocode_context_error_message(x[[i]], cnd), call. = FALSE)
+      }
+    )
     processed <- processed + x_n
     addr_progress_update(
       processed,
@@ -589,10 +638,16 @@ geocode_zip <- function(
   no <- which(is.na(out$matched_street))
   out$matched_zipcode <- zpcd
 
-  if (length(no) != 0 && zip_variants) {
+  variant_zipcodes <- if (zip_variants) {
+    zipcode_variant(zpcd, variant = zip_variant)
+  } else {
+    character()
+  }
+
+  if (length(no) != 0 && zip_variants && length(variant_zipcodes) > 0L) {
     out$matched_zipcode[no] <- NA_character_
     ref_variant <- taf_zip(
-      zipcode_variant(zpcd, variant = zip_variant),
+      variant_zipcodes,
       map = TRUE,
       year = year,
       version = version

--- a/R/taf.R
+++ b/R/taf.R
@@ -30,22 +30,22 @@
 #' Sys.setenv("R_USER_DATA_DIR" = tempfile())
 #' taf_install("39061", "2025")
 #'
-#' taf()
+#' if (requireNamespace("arrow", quietly = TRUE) &&
+#'   requireNamespace("dplyr", quietly = TRUE)) {
+#'   taf()
 #'
-#' # use dplyr verbs to query
-#' library(dplyr, warn.conflicts = FALSE)
-#'
-#' # find top ten most frequent street name-posttype combinations
-#' taf() |>
-#'   group_by(street_name, street_posttype) |>
-#'   summarize(
-#'     n_zips = n_distinct(ZIP),
-#'     n_ranges = n(),
-#'     .groups = "drop"
-#'   ) |>
-#'   arrange(desc(n_zips), desc(n_ranges)) |>
-#'   collect() |>
-#'   slice(1:10)
+#'   # find top ten most frequent street name-posttype combinations
+#'   taf() |>
+#'     dplyr::group_by(street_name, street_posttype) |>
+#'     dplyr::summarize(
+#'       n_zips = dplyr::n_distinct(ZIP),
+#'       n_ranges = dplyr::n(),
+#'       .groups = "drop"
+#'     ) |>
+#'     dplyr::arrange(dplyr::desc(n_zips), dplyr::desc(n_ranges)) |>
+#'     dplyr::collect() |>
+#'     dplyr::slice(1:10)
+#' }
 taf <- function(year = as.character(2025:2011), version = "v1") {
   check_installed("arrow", "to open the multi-file taf dataset")
   stopifnot(
@@ -695,11 +695,20 @@ taf_needed_zipcodes <- function(
       vctrs::vec_rbind,
       lapply(seq_along(zip_variant), function(i) {
         variant <- zip_variant[[i]]
+        ZIP <- zipcode_variant(zip, variant = variant)
+        if (length(ZIP) == 0L) {
+          return(tibble::tibble(
+            source_zip = character(),
+            source_zip_variant = character(),
+            source_zip_variant_rank = integer(),
+            ZIP = character()
+          ))
+        }
         tibble::tibble(
           source_zip = zip,
           source_zip_variant = variant,
           source_zip_variant_rank = i,
-          ZIP = zipcode_variant(zip, variant = variant)
+          ZIP = ZIP
         )
       })
     )

--- a/man/taf.Rd
+++ b/man/taf.Rd
@@ -54,22 +54,22 @@ ADDRFEAT full name, and the \code{street_tag_parsed} column is set to TRUE.
 Sys.setenv("R_USER_DATA_DIR" = tempfile())
 taf_install("39061", "2025")
 
-taf()
+if (requireNamespace("arrow", quietly = TRUE) &&
+  requireNamespace("dplyr", quietly = TRUE)) {
+  taf()
 
-# use dplyr verbs to query
-library(dplyr, warn.conflicts = FALSE)
-
-# find top ten most frequent street name-posttype combinations
-taf() |>
-  group_by(street_name, street_posttype) |>
-  summarize(
-    n_zips = n_distinct(ZIP),
-    n_ranges = n(),
-    .groups = "drop"
-  ) |>
-  arrange(desc(n_zips), desc(n_ranges)) |>
-  collect() |>
-  slice(1:10)
+  # find top ten most frequent street name-posttype combinations
+  taf() |>
+    dplyr::group_by(street_name, street_posttype) |>
+    dplyr::summarize(
+      n_zips = dplyr::n_distinct(ZIP),
+      n_ranges = dplyr::n(),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(dplyr::desc(n_zips), dplyr::desc(n_ranges)) |>
+    dplyr::collect() |>
+    dplyr::slice(1:10)
+}
 Sys.setenv("R_USER_DATA_DIR" = tempfile())
 taf_install("39061", "2025")
 }

--- a/tests/testthat/test-addr_part_match.R
+++ b/tests/testthat/test-addr_part_match.R
@@ -185,6 +185,11 @@ test_that("zipcode_variant returns known variants", {
   expect_equal(zipcode_variant(NA_character_), NA_character_)
 })
 
+test_that("zipcode_variant omits generated invalid ZIP codes", {
+  expect_equal(zipcode_variant("00100", "minus1"), character())
+  expect_false("00099" %in% zipcode_variant("00100"))
+})
+
 test_that("match_zipcodes uses known zipcode examples", {
   x <- c("45222", "45219", "45219", "45220", "45220", "", NA_character_)
   y <- c("42522", "45200", "45219", "45221", "45223", "45321", "")

--- a/tests/testthat/test-as_addr.R
+++ b/tests/testthat/test-as_addr.R
@@ -190,6 +190,16 @@ test_that("as_addr makes malformed parsed zipcodes missing", {
   )
 })
 
+test_that("as_addr malformed zipcode warning identifies affected inputs", {
+  expect_warning(
+    as_addr(c(
+      "123 Main Street Anytown IL 00021",
+      "123 Main Street Anytown IL 45220"
+    )),
+    "Affected address examples: 1:"
+  )
+})
+
 test_that("as_addr deals with some seriously messy addresses", {
   as_addr(c(
     "1234Main St Cincinnati OH 45229",

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -528,6 +528,73 @@ test_that("geocode_zip respects zipcode variant controls", {
   expect_true(is.na(out_none$matched_street))
 })
 
+test_that("geocode_zip skips generated invalid zipcode variants", {
+  taf_zip_calls <- list()
+  local_mocked_bindings(
+    taf_zip = function(zipcode, map = TRUE, ...) {
+      taf_zip_calls <<- c(taf_zip_calls, list(zipcode))
+      expect_false(any(is_invalid_zipcode(zipcode)))
+      tibble::tibble(
+        ZIP = character(),
+        addr_street = addr_street()[0],
+        FROMHN = integer(),
+        TOHN = integer(),
+        PARITY = character(),
+        side = character(),
+        OFFSET = numeric(),
+        s2_geography = s2::as_s2_geography(character())
+      )
+    },
+    match_addr_street = function(x, y, ...) {
+      addr_street(rep(NA_character_, length(x)))
+    }
+  )
+  x <- addr(
+    addr_number(digits = "10"),
+    addr_street(name = "Main", posttype = "St"),
+    addr_place(zipcode = "00100")
+  )
+
+  out <- geocode_zip(
+    x,
+    offset = 0,
+    zip_variant = "minus1",
+    taf_install = FALSE,
+    taf_check = FALSE
+  )
+
+  expect_length(taf_zip_calls, 1L)
+  expect_equal(taf_zip_calls[[1]], "00100")
+  expect_true(is.na(out$matched_zipcode))
+  expect_true(is.na(out$matched_street))
+})
+
+test_that("geocode reports ZIP and address context for ZIP-level errors", {
+  local_mocked_bindings(
+    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    geocode_use_mirai = function() FALSE,
+    geocode_zip = function(...) {
+      stop("boom", call. = FALSE)
+    }
+  )
+  x <- addr(
+    addr_number(digits = "10"),
+    addr_street(name = "Main", posttype = "St"),
+    addr_place(zipcode = "45220")
+  )
+
+  err <- tryCatch(
+    geocode(x, taf_install = FALSE, progress = FALSE),
+    error = function(cnd) cnd
+  )
+  msg <- conditionMessage(err)
+
+  expect_s3_class(err, "error")
+  expect_match(msg, "geocoding failed for ZIP 45220", fixed = TRUE)
+  expect_match(msg, "Affected address examples:", fixed = TRUE)
+  expect_match(msg, "Original error: boom", fixed = TRUE)
+})
+
 test_that("geocode_zip offsets matched points by TIGER side", {
   local_mocked_bindings(
     taf_zip = function(zipcode, map = TRUE, ...) {


### PR DESCRIPTION
this fixes a bug where zipcode variants could be generated that were not valid zipcodes, causing the tiger geocoder to error internally

also added more helpful reporting for geocoding failures