### PR TITLE
reduce geocode memory use

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -212,7 +212,7 @@ geocode <- function(
       geocode_result_group_count_text(length(gcd))
     )
   }
-  gcd <- geocode_assemble_results(plan, gcd)
+  gcd <- geocode_assemble_results(plan, gcd, progress = progress)
 
   if (add_s2_cell) {
     if (progress) {
@@ -260,21 +260,121 @@ geocode_plan_taf_addr <- function(x) {
   x$unique_addr[x$non_missing_zip_idx]
 }
 
-geocode_assemble_results <- function(plan, results) {
-  out <- geocode_no_match(plan$unique_addr)
-  if (length(results) == 0L) {
-    return(out)
+geocode_assemble_results <- function(plan, results, progress = FALSE) {
+  n <- length(plan$unique_addr)
+  if (n == 0L || length(results) == 0L) {
+    return(geocode_no_match(plan$unique_addr))
+  }
+  result_names <- names(results)
+  if (is.null(result_names) || any(result_names == "")) {
+    result_names <- names(plan$zip_groups)
+    if (length(result_names) != length(results)) {
+      stop("geocoding result group count does not match planned ZIP groups", call. = FALSE)
+    }
+    names(results) <- result_names
   }
 
+  if (progress) {
+    geocode_progress_message("validating geocode result groups")
+  }
+  result_rows <- vector("list", length(results))
+  names(result_rows) <- names(results)
   for (zip in names(results)) {
     rows <- plan$zip_group_idx[[zip]]
+    if (is.null(rows)) {
+      stop("geocoding returned an unexpected ZIP result group: ", zip, call. = FALSE)
+    }
     result <- results[[zip]]
     geocode_check_result(result, rows, zip)
-    out$matched_zipcode[rows] <- result$matched_zipcode
-    out$matched_street[rows] <- result$matched_street
-    out$matched_geography[rows] <- result$matched_geography
+    result_rows[[zip]] <- rows
   }
-  out
+
+  if (progress) {
+    geocode_progress_message("concatenating geocode result columns")
+  }
+  row_order <- unlist(result_rows, use.names = FALSE)
+  matched_zipcode <- unlist(
+    lapply(results, `[[`, "matched_zipcode"),
+    use.names = FALSE
+  )
+  matched_street <- geocode_c_addr_street(
+    lapply(results, `[[`, "matched_street")
+  )
+  matched_geography <- geocode_c_s2_geography(
+    lapply(results, `[[`, "matched_geography")
+  )
+
+  if (length(plan$missing_zip_idx) > 0L) {
+    row_order <- c(row_order, plan$missing_zip_idx)
+    matched_zipcode <- c(
+      matched_zipcode,
+      rep(NA_character_, length(plan$missing_zip_idx))
+    )
+    matched_street <- geocode_c_addr_street(list(
+      matched_street,
+      addr_street(rep(NA_character_, length(plan$missing_zip_idx)))
+    ))
+    matched_geography <- geocode_c_s2_geography(list(
+      matched_geography,
+      s2::as_s2_geography(rep(NA_character_, length(plan$missing_zip_idx)))
+    ))
+  }
+
+  if (progress) {
+    geocode_progress_message("reordering geocode result rows")
+  }
+  restore_unique_idx <- match(seq_len(n), row_order)
+  if (anyNA(restore_unique_idx) || length(unique(row_order)) != n) {
+    stop("geocoding result rows do not match planned unique addr rows", call. = FALSE)
+  }
+
+  tibble::tibble(
+    addr = plan$unique_addr,
+    matched_zipcode = matched_zipcode[restore_unique_idx],
+    matched_street = matched_street[restore_unique_idx],
+    matched_geography = matched_geography[restore_unique_idx]
+  )
+}
+
+geocode_c_addr_street <- function(x) {
+  x <- x[lengths(x) > 0L]
+  if (length(x) == 0L) {
+    return(addr_street(
+      predirectional = character(),
+      premodifier = character(),
+      pretype = character(),
+      name = character(),
+      posttype = character(),
+      postdirectional = character(),
+      map_posttype = FALSE,
+      map_directional = FALSE,
+      map_pretype = FALSE,
+      map_ordinal = FALSE
+    ))
+  }
+  addr_street(
+    predirectional = unlist(lapply(x, \(.) .@predirectional), use.names = FALSE),
+    premodifier = unlist(lapply(x, \(.) .@premodifier), use.names = FALSE),
+    pretype = unlist(lapply(x, \(.) .@pretype), use.names = FALSE),
+    name = unlist(lapply(x, \(.) .@name), use.names = FALSE),
+    posttype = unlist(lapply(x, \(.) .@posttype), use.names = FALSE),
+    postdirectional = unlist(
+      lapply(x, \(.) .@postdirectional),
+      use.names = FALSE
+    ),
+    map_posttype = FALSE,
+    map_directional = FALSE,
+    map_pretype = FALSE,
+    map_ordinal = FALSE
+  )
+}
+
+geocode_c_s2_geography <- function(x) {
+  x <- x[lengths(x) > 0L]
+  if (length(x) == 0L) {
+    return(s2::as_s2_geography(character()))
+  }
+  do.call(c, x)
 }
 
 geocode_check_result <- function(x, rows, zip) {
@@ -553,6 +653,7 @@ lapply_pb <- function(x, FUN, ...) {
   on.exit(cat("\n"), add = TRUE)
 
   out <- vector("list", length(x))
+  names(out) <- names(x)
   for (i in seq_along(x)) {
     zip <- names(x)[[i]]
     x_n <- length(x[[i]])

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -19,7 +19,8 @@
 #' return `NA`.
 #' @param x an addr vector (`?as_addr`)
 #' @param offset number of meters to offset geocode from street line
-#' @param progress logical; show a ZIP-code progress bar while geocoding?
+#' @param progress logical; show progress messages and a ZIP-code progress bar
+#'   while geocoding?
 #' @param taf_install logical; install missing county TAF files needed for
 #'   input ZIP codes and selected ZIP code variants before geocoding? If
 #'   `FALSE`, geocoding proceeds with installed files only and warns when
@@ -125,9 +126,25 @@ geocode <- function(
     match_street_type = match_street_type,
     match_street_directional = match_street_directional
   )
+  if (progress) {
+    geocode_progress_message(
+      "preparing geocoding input (",
+      geocode_format_count(length(x)),
+      " addr)"
+    )
+  }
   xu <- unique(x)
   missing_zip <- is.na(xu@place@zipcode) | xu@place@zipcode == ""
   if (any(!missing_zip)) {
+    if (progress) {
+      geocode_progress_message(
+        geocode_prepare_taf_progress_text(
+          xu[!missing_zip],
+          taf_install = taf_install,
+          zip_variants = zip_variants
+        )
+      )
+    }
     geocode_prepare_taf(
       xu[!missing_zip],
       year = year,
@@ -137,8 +154,14 @@ geocode <- function(
       taf_install = taf_install,
       taf_redownload = taf_redownload
     )
+    if (progress) {
+      geocode_progress_message("TIGER address feature file check complete")
+    }
   }
   z_list <- split(xu[!missing_zip], xu[!missing_zip]@place@zipcode)
+  if (progress) {
+    geocode_progress_message(geocode_group_progress_text(z_list))
+  }
 
   gcd <- geocode_map(
     z_list,
@@ -175,7 +198,10 @@ geocode_map <- function(x, FUN, progress, ...) {
     return(list())
   }
   if (geocode_use_mirai()) {
-    return(geocode_map_mirai(x, FUN, ...))
+    if (progress) {
+      geocode_progress_message(geocode_mirai_progress_text(x))
+    }
+    return(geocode_map_mirai(x, FUN, progress = progress, ...))
   }
   if (progress) {
     return(lapply_pb(x, FUN, ...))
@@ -188,7 +214,7 @@ geocode_use_mirai <- function() {
     mirai::daemons_set()
 }
 
-geocode_map_mirai <- function(x, FUN, ...) {
+geocode_map_mirai <- function(x, FUN, progress, ...) {
   geocode_args <- list(...)
   load_dev <- geocode_load_dev_workers()
   package_path <- if (load_dev) {
@@ -204,7 +230,12 @@ geocode_map_mirai <- function(x, FUN, ...) {
       package_path = package_path,
       load_dev = load_dev
     )
-  )[.progress]
+  )
+  out <- if (progress) {
+    out[.progress]
+  } else {
+    out[]
+  }
   geocode_check_parallel_results(out)
   out <- lapply(out, geocode_restore_parallel_result)
   out
@@ -367,8 +398,78 @@ geocode_progress_text <- function(zip, x_n, y_n) {
   sprintf(
     "geocoding %s (%s addr to %s addr_street)",
     zip,
-    prettyNum(x_n, big.mark = ",", preserve.width = "none"),
-    prettyNum(y_n, big.mark = ",", preserve.width = "none")
+    geocode_format_count(x_n),
+    geocode_format_count(y_n)
+  )
+}
+
+geocode_progress_message <- function(...) {
+  cat(..., "\n", sep = "")
+  utils::flush.console()
+}
+
+geocode_format_count <- function(x) {
+  prettyNum(x, big.mark = ",", preserve.width = "none")
+}
+
+geocode_prepare_taf_progress_text <- function(
+  x,
+  taf_install,
+  zip_variants
+) {
+  has_zip <- !is.na(x@place@zipcode) & x@place@zipcode != ""
+  zipcodes <- unique(x@place@zipcode[has_zip])
+  install_text <- if (taf_install) {
+    "installing missing county files if needed"
+  } else {
+    "using installed files only"
+  }
+  variant_text <- if (zip_variants) {
+    " plus ZIP variants"
+  } else {
+    ""
+  }
+  sprintf(
+    "checking TIGER address feature files for %s%s (%s)",
+    geocode_zip_count_text(length(zipcodes)),
+    variant_text,
+    install_text
+  )
+}
+
+geocode_group_progress_text <- function(x) {
+  sprintf(
+    "grouped %s into %s",
+    geocode_addr_count_text(sum(lengths(x))),
+    geocode_zip_group_count_text(length(x))
+  )
+}
+
+geocode_mirai_progress_text <- function(x) {
+  sprintf(
+    "dispatching %s across mirai workers (%s)",
+    geocode_zip_group_count_text(length(x)),
+    geocode_addr_count_text(sum(lengths(x)))
+  )
+}
+
+geocode_addr_count_text <- function(n) {
+  paste(geocode_format_count(n), "unique addr")
+}
+
+geocode_zip_group_count_text <- function(n) {
+  sprintf(
+    "%s ZIP %s",
+    geocode_format_count(n),
+    if (n == 1L) "group" else "groups"
+  )
+}
+
+geocode_zip_count_text <- function(n) {
+  sprintf(
+    "%s ZIP %s",
+    geocode_format_count(n),
+    if (n == 1L) "code" else "codes"
   )
 }
 

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -139,23 +139,30 @@ geocode <- function(
     match_street_type = match_street_type,
     match_street_directional = match_street_directional
   )
-  progress_message <- if (progress) {
-    geocode_progress_timer()
-  } else {
-    NULL
-  }
   if (progress) {
-    progress_message(
+    progress_step <- geocode_progress_step_begin(
       "preparing geocoding input (",
-      geocode_format_count(length(x)),
-      " addr)"
+      geocode_input_addr_count_text(length(x)),
+      ")"
     )
   }
   plan <- geocode_plan(x)
+  if (progress) {
+    geocode_progress_step_end(
+      progress_step,
+      "preparing geocoding input (",
+      geocode_input_addr_count_text(length(x)),
+      "; ",
+      geocode_addr_count_text(length(plan$unique_addr)),
+      "; ",
+      geocode_zip_group_count_text(length(plan$zip_groups)),
+      ")"
+    )
+  }
   taf_addr <- geocode_plan_taf_addr(plan)
   if (length(taf_addr) > 0L) {
     if (progress) {
-      progress_message(
+      progress_step <- geocode_progress_step_begin(
         geocode_prepare_taf_progress_text(
           taf_addr,
           taf_install = taf_install,
@@ -173,18 +180,14 @@ geocode <- function(
       taf_redownload = taf_redownload
     )
     if (progress) {
-      progress_message("TIGER address feature file check complete")
+      geocode_progress_step_end(progress_step)
     }
-  }
-  if (progress) {
-    progress_message(geocode_group_progress_text(plan$zip_groups))
   }
 
   gcd <- geocode_map(
     plan$zip_groups,
     geocode_zip,
     progress = progress,
-    progress_message = progress_message,
     offset = offset,
     name_phonetic_dist = name_phonetic_dist,
     name_fuzzy_dist = name_fuzzy_dist,
@@ -198,48 +201,30 @@ geocode <- function(
     taf_redownload = taf_redownload,
     taf_check = FALSE
   )
-  if (length(plan$missing_zip_idx) > 0L) {
-    if (progress) {
-      progress_message(
-        "adding no-match results for ",
-        geocode_addr_count_text(length(plan$missing_zip_idx)),
-        " without ZIP codes"
-      )
-    }
-  }
-  if (length(gcd) == 0L && length(plan$unique_addr) == 0L) {
-    if (progress) {
-      progress_message("creating no-match geocode results")
-    }
-  }
-  if (progress) {
-    progress_message(
-      "combining geocode results from ",
-      geocode_result_group_count_text(length(gcd))
-    )
-  }
   gcd <- geocode_assemble_results(
     plan,
     gcd,
-    progress = progress,
-    progress_message = progress_message
+    progress = progress
   )
 
   if (add_s2_cell) {
     if (progress) {
-      progress_message("computing S2 cells")
+      progress_step <- geocode_progress_step_begin("computing S2 cells")
     }
     gcd$s2_cell <- s2::as_s2_cell(gcd$matched_geography)
+    if (progress) {
+      geocode_progress_step_end(progress_step)
+    }
   }
   if (progress) {
-    progress_message(
+    progress_step <- geocode_progress_step_begin(
       "restoring geocode output to ",
       geocode_input_addr_count_text(length(x))
     )
   }
   out <- gcd[plan$restore_idx, , drop = FALSE]
   if (progress) {
-    progress_message("geocoding complete")
+    geocode_progress_step_end(progress_step)
   }
   return(out)
 }
@@ -274,12 +259,20 @@ geocode_plan_taf_addr <- function(x) {
 geocode_assemble_results <- function(
   plan,
   results,
-  progress = FALSE,
-  progress_message = geocode_progress_message
+  progress = FALSE
 ) {
   n <- length(plan$unique_addr)
   if (n == 0L || length(results) == 0L) {
-    return(geocode_no_match(plan$unique_addr))
+    if (progress) {
+      progress_step <- geocode_progress_step_begin(
+        "creating no-match geocode results"
+      )
+    }
+    out <- geocode_no_match(plan$unique_addr)
+    if (progress) {
+      geocode_progress_step_end(progress_step)
+    }
+    return(out)
   }
   result_names <- names(results)
   if (is.null(result_names) || any(result_names == "")) {
@@ -291,7 +284,11 @@ geocode_assemble_results <- function(
   }
 
   if (progress) {
-    progress_message("validating geocode result groups")
+    progress_step <- geocode_progress_step_begin(
+      "validating geocode result groups (",
+      geocode_result_group_count_text(length(results)),
+      ")"
+    )
   }
   result_rows <- vector("list", length(results))
   names(result_rows) <- names(results)
@@ -304,9 +301,14 @@ geocode_assemble_results <- function(
     geocode_check_result(result, rows, zip)
     result_rows[[zip]] <- rows
   }
+  if (progress) {
+    geocode_progress_step_end(progress_step)
+  }
 
   if (progress) {
-    progress_message("concatenating geocode result columns")
+    progress_step <- geocode_progress_step_begin(
+      "concatenating geocode result columns"
+    )
   }
   row_order <- unlist(result_rows, use.names = FALSE)
   matched_zipcode <- unlist(
@@ -335,21 +337,28 @@ geocode_assemble_results <- function(
       s2::as_s2_geography(rep(NA_character_, length(plan$missing_zip_idx)))
     ))
   }
+  if (progress) {
+    geocode_progress_step_end(progress_step)
+  }
 
   if (progress) {
-    progress_message("reordering geocode result rows")
+    progress_step <- geocode_progress_step_begin("reordering geocode result rows")
   }
   restore_unique_idx <- match(seq_len(n), row_order)
   if (anyNA(restore_unique_idx) || length(unique(row_order)) != n) {
     stop("geocoding result rows do not match planned unique addr rows", call. = FALSE)
   }
 
-  tibble::tibble(
+  out <- tibble::tibble(
     addr = plan$unique_addr,
     matched_zipcode = matched_zipcode[restore_unique_idx],
     matched_street = matched_street[restore_unique_idx],
     matched_geography = matched_geography[restore_unique_idx]
   )
+  if (progress) {
+    geocode_progress_step_end(progress_step)
+  }
+  out
 }
 
 geocode_c_addr_street <- function(x) {
@@ -435,21 +444,16 @@ geocode_map <- function(
   x,
   FUN,
   progress,
-  progress_message = geocode_progress_message,
   ...
 ) {
   if (length(x) == 0L) {
     return(list())
   }
   if (geocode_use_mirai()) {
-    if (progress) {
-      progress_message(geocode_mirai_progress_text(x))
-    }
     return(geocode_map_mirai(
       x,
       FUN,
       progress = progress,
-      progress_message = progress_message,
       ...
     ))
   }
@@ -468,7 +472,6 @@ geocode_map_mirai <- function(
   x,
   FUN,
   progress,
-  progress_message = geocode_progress_message,
   ...
 ) {
   geocode_args <- list(...)
@@ -489,12 +492,12 @@ geocode_map_mirai <- function(
   )
   out <- geocode_collect_mirai(out, x, progress = progress)
   if (progress) {
-    progress_message("mirai workers complete; restoring geographies")
+    progress_step <- geocode_progress_step_begin("restoring mirai geographies")
   }
   geocode_check_parallel_results(out)
   out <- lapply(out, geocode_restore_parallel_result)
   if (progress) {
-    progress_message("mirai geocoding results restored")
+    geocode_progress_step_end(progress_step)
   }
   out
 }
@@ -731,28 +734,42 @@ geocode_progress_text <- function(zip, x_n, y_n) {
   )
 }
 
-geocode_progress_message <- function(...) {
-  cat(..., "\n", sep = "")
+geocode_progress_step_begin <- function(...) {
+  text <- geocode_progress_step_text(...)
+  cat(text, sep = "")
   utils::flush.console()
+  list(
+    text = text,
+    started = proc.time()[["elapsed"]]
+  )
 }
 
-geocode_progress_timer <- function() {
-  started <- proc.time()[["elapsed"]]
-  last <- started
-  function(...) {
-    now <- proc.time()[["elapsed"]]
-    step <- now - last
-    total <- now - started
-    last <<- now
-    geocode_progress_message(
-      ...,
-      " (+",
-      geocode_progress_duration_text(step),
-      "; total ",
-      geocode_progress_duration_text(total),
-      ")"
-    )
+geocode_progress_step_end <- function(step, ...) {
+  parts <- list(...)
+  text <- if (length(parts) == 0L) {
+    step$text
+  } else {
+    paste0(parts, collapse = "")
   }
+  elapsed <- proc.time()[["elapsed"]] - step$started
+  cat(
+    "\r\033[2K",
+    text,
+    " (+",
+    geocode_progress_duration_text(elapsed),
+    ")\n",
+    sep = ""
+  )
+  utils::flush.console()
+  invisible(step)
+}
+
+geocode_progress_step_text <- function(...) {
+  parts <- list(...)
+  if (length(parts) == 0L) {
+    return("")
+  }
+  paste0(parts, collapse = "")
 }
 
 geocode_progress_duration_text <- function(x) {
@@ -794,22 +811,6 @@ geocode_prepare_taf_progress_text <- function(
     geocode_zip_count_text(length(zipcodes)),
     variant_text,
     install_text
-  )
-}
-
-geocode_group_progress_text <- function(x) {
-  sprintf(
-    "grouped %s into %s",
-    geocode_addr_count_text(sum(lengths(x))),
-    geocode_zip_group_count_text(length(x))
-  )
-}
-
-geocode_mirai_progress_text <- function(x) {
-  sprintf(
-    "dispatching %s across mirai workers (%s)",
-    geocode_zip_group_count_text(length(x)),
-    geocode_addr_count_text(sum(lengths(x)))
   )
 }
 

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -27,13 +27,17 @@
 #'   needed county files are missing.
 #' @param taf_redownload logical; re-download cached TIGER ZIP files when
 #'   installing missing TAF counties?
+#' @param add_s2_cell logical; add an `s2_cell` column computed from matched
+#'   geographies? Defaults to `TRUE`; set to `FALSE` to skip this final
+#'   computation.
 #' @inheritParams match_addr_street
 #' @inheritParams match_zipcodes
 #' @inheritParams taf
 #' @returns A tibble with columns `addr` (the input addr vector),
 #'   `matched_zipcode` (character vector), `matched_street` (`addr_street`
-#'   vector), `matched_geography` (`s2_geography` point vector), and `s2_cell`
-#'   (`s2_cell` vector).
+#'   vector), and `matched_geography` (`s2_geography` point vector). When
+#'   `add_s2_cell = TRUE`, the tibble also includes `s2_cell` (`s2_cell`
+#'   vector).
 #' @details
 #' `geocode_zip()` is the workhorse function and operates on addr vectors
 #' with the same ZIP code; use `geocode()` to geocode an addr vector
@@ -102,6 +106,7 @@ geocode <- function(
   taf_install = TRUE,
   taf_redownload = FALSE,
   offset = 10L,
+  add_s2_cell = TRUE,
   progress = interactive()
 ) {
   stopifnot(
@@ -115,6 +120,9 @@ geocode <- function(
     "taf_redownload must be TRUE or FALSE" = is.logical(taf_redownload) &&
       length(taf_redownload) == 1L &&
       !is.na(taf_redownload),
+    "add_s2_cell must be TRUE or FALSE" = is.logical(add_s2_cell) &&
+      length(add_s2_cell) == 1L &&
+      !is.na(add_s2_cell),
     "version must be a character vector" = is.character(version),
     "version must be length one" = length(version) == 1L,
     "version must not be missing" = !is.na(version),
@@ -138,20 +146,20 @@ geocode <- function(
       " addr)"
     )
   }
-  xu <- unique(x)
-  missing_zip <- is.na(xu@place@zipcode) | xu@place@zipcode == ""
-  if (any(!missing_zip)) {
+  plan <- geocode_plan(x)
+  taf_addr <- geocode_plan_taf_addr(plan)
+  if (length(taf_addr) > 0L) {
     if (progress) {
       geocode_progress_message(
         geocode_prepare_taf_progress_text(
-          xu[!missing_zip],
+          taf_addr,
           taf_install = taf_install,
           zip_variants = zip_variants
         )
       )
     }
     geocode_prepare_taf(
-      xu[!missing_zip],
+      plan,
       year = year,
       version = version,
       zip_variants = zip_variants,
@@ -163,13 +171,12 @@ geocode <- function(
       geocode_progress_message("TIGER address feature file check complete")
     }
   }
-  z_list <- split(xu[!missing_zip], xu[!missing_zip]@place@zipcode)
   if (progress) {
-    geocode_progress_message(geocode_group_progress_text(z_list))
+    geocode_progress_message(geocode_group_progress_text(plan$zip_groups))
   }
 
   gcd <- geocode_map(
-    z_list,
+    plan$zip_groups,
     geocode_zip,
     progress = progress,
     offset = offset,
@@ -185,21 +192,19 @@ geocode <- function(
     taf_redownload = taf_redownload,
     taf_check = FALSE
   )
-  if (any(missing_zip)) {
+  if (length(plan$missing_zip_idx) > 0L) {
     if (progress) {
       geocode_progress_message(
         "adding no-match results for ",
-        geocode_addr_count_text(sum(missing_zip)),
+        geocode_addr_count_text(length(plan$missing_zip_idx)),
         " without ZIP codes"
       )
     }
-    gcd <- c(gcd, list(missing_zip = geocode_no_match(xu[missing_zip])))
   }
-  if (length(gcd) == 0L) {
+  if (length(gcd) == 0L && length(plan$unique_addr) == 0L) {
     if (progress) {
       geocode_progress_message("creating no-match geocode results")
     }
-    gcd <- list(geocode_no_match(xu))
   }
   if (progress) {
     geocode_progress_message(
@@ -207,23 +212,107 @@ geocode <- function(
       geocode_result_group_count_text(length(gcd))
     )
   }
-  gcd <- do.call(rbind, gcd)
+  gcd <- geocode_assemble_results(plan, gcd)
 
+  if (add_s2_cell) {
+    if (progress) {
+      geocode_progress_message("computing S2 cells")
+    }
+    gcd$s2_cell <- s2::as_s2_cell(gcd$matched_geography)
+  }
   if (progress) {
     geocode_progress_message(
       "restoring geocode output to ",
       geocode_input_addr_count_text(length(x))
     )
   }
-  out <- gcd[match(format(x), format(gcd$addr)), ]
-  if (progress) {
-    geocode_progress_message("computing S2 cells")
-  }
-  out$s2_cell <- s2::as_s2_cell(out$matched_geography)
+  out <- gcd[plan$restore_idx, , drop = FALSE]
   if (progress) {
     geocode_progress_message("geocoding complete")
   }
   return(out)
+}
+
+geocode_plan <- function(x) {
+  key <- as.character(x)
+  unique_row <- !duplicated(key)
+  unique_addr <- x[unique_row]
+  unique_key <- key[unique_row]
+  restore_idx <- match(key, unique_key)
+  missing_zip <- is.na(unique_addr@place@zipcode) |
+    unique_addr@place@zipcode == ""
+  non_missing_zip_idx <- which(!missing_zip)
+  zip <- unique_addr@place@zipcode[non_missing_zip_idx]
+  zip_groups <- split(unique_addr[non_missing_zip_idx], zip, drop = TRUE)
+  zip_group_idx <- split(non_missing_zip_idx, zip, drop = TRUE)
+
+  list(
+    unique_addr = unique_addr,
+    restore_idx = restore_idx,
+    missing_zip_idx = which(missing_zip),
+    non_missing_zip_idx = non_missing_zip_idx,
+    zip_groups = zip_groups,
+    zip_group_idx = zip_group_idx
+  )
+}
+
+geocode_plan_taf_addr <- function(x) {
+  x$unique_addr[x$non_missing_zip_idx]
+}
+
+geocode_assemble_results <- function(plan, results) {
+  out <- geocode_no_match(plan$unique_addr)
+  if (length(results) == 0L) {
+    return(out)
+  }
+
+  for (zip in names(results)) {
+    rows <- plan$zip_group_idx[[zip]]
+    result <- results[[zip]]
+    geocode_check_result(result, rows, zip)
+    out$matched_zipcode[rows] <- result$matched_zipcode
+    out$matched_street[rows] <- result$matched_street
+    out$matched_geography[rows] <- result$matched_geography
+  }
+  out
+}
+
+geocode_check_result <- function(x, rows, zip) {
+  if (!is.data.frame(x)) {
+    stop("geocoding result for ZIP ", zip, " must be a data frame", call. = FALSE)
+  }
+  required <- c("addr", "matched_zipcode", "matched_street", "matched_geography")
+  missing <- setdiff(required, names(x))
+  if (length(missing) > 0L) {
+    stop(
+      "geocoding result for ZIP ",
+      zip,
+      " is missing required column(s): ",
+      paste(missing, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  if (nrow(x) != length(rows)) {
+    stop(
+      "geocoding result for ZIP ",
+      zip,
+      " returned ",
+      nrow(x),
+      " rows for ",
+      length(rows),
+      " input rows",
+      call. = FALSE
+    )
+  }
+  stopifnot(
+    "geocoding result addr column must be an addr vector" =
+      inherits(x$addr, "addr"),
+    "geocoding result matched_street column must be an addr_street vector" =
+      inherits(x$matched_street, "addr_street"),
+    "geocoding result matched_geography column must be an s2_geography vector" =
+      inherits(x$matched_geography, "s2_geography")
+  )
+  invisible(x)
 }
 
 geocode_map <- function(x, FUN, progress, ...) {
@@ -681,7 +770,7 @@ geocode_no_match <- function(x) {
 #' @param x a data frame returned by [geocode()]
 #' @returns A tibble with atomic columns suitable for JSON serialization.
 #'   `geocode_table()` includes the input address, geocode stage, matched ZIP
-#'   code, matched street, and S2 cell as character columns.
+#'   code, matched street, and, when present, S2 cell as character columns.
 #' @export
 geocode_table <- function(x) {
   stopifnot(
@@ -694,8 +783,14 @@ geocode_table <- function(x) {
       x$matched_street,
       "addr_street"
     ),
-    "x must contain an s2_cell column" = "s2_cell" %in% names(x),
-    "x$s2_cell must be an s2_cell vector" = inherits(x$s2_cell, "s2_cell")
+    "x must contain a matched_geography column" =
+      "matched_geography" %in% names(x),
+    "x$matched_geography must be an s2_geography vector" = inherits(
+      x$matched_geography,
+      "s2_geography"
+    ),
+    "x$s2_cell must be an s2_cell vector" =
+      !("s2_cell" %in% names(x)) || inherits(x$s2_cell, "s2_cell")
   )
 
   out <- data.frame(
@@ -703,10 +798,12 @@ geocode_table <- function(x) {
     geocode_stage = as.character(geocode_stage(x)),
     matched_zipcode = x$matched_zipcode,
     matched_street = as.character(x$matched_street),
-    s2_cell = as.character(x$s2_cell),
     check.names = FALSE,
     stringsAsFactors = FALSE
   )
+  if ("s2_cell" %in% names(x)) {
+    out$s2_cell <- as.character(x$s2_cell)
+  }
   tibble::as_tibble(out)
 }
 
@@ -731,20 +828,24 @@ geocode_stage <- function(x) {
       x$matched_street,
       "addr_street"
     ),
-    "x must contain an s2_cell column" = "s2_cell" %in% names(x),
-    "x$s2_cell must be an s2_cell vector" = inherits(x$s2_cell, "s2_cell")
+    "x must contain a matched_geography column" =
+      "matched_geography" %in% names(x),
+    "x$matched_geography must be an s2_geography vector" = inherits(
+      x$matched_geography,
+      "s2_geography"
+    )
   )
 
   matched_street <- as.character(x$matched_street)
   input_zipcode <- x$addr@place@zipcode
   has_zipcode <- !is.na(x$matched_zipcode) & x$matched_zipcode != ""
   has_street <- has_zipcode & !is.na(matched_street) & matched_street != ""
-  has_range <- has_street & !is.na(x$s2_cell)
   has_exact_zipcode <- has_street &
     !is.na(input_zipcode) &
     input_zipcode != "" &
     x$matched_zipcode == input_zipcode
   has_variant <- has_street & !has_exact_zipcode
+  has_range <- has_street & !is.na(x$matched_geography)
 
   out <- rep("none", nrow(x))
   out[has_street] <- "street"
@@ -776,29 +877,80 @@ geocode_prepare_taf <- function(
     return(invisible(NULL))
   }
 
-  missing_args <- list(
-    x = x,
+  taf_addr <- if (is.list(x) && !is.null(x$unique_addr)) {
+    geocode_plan_taf_addr(x)
+  } else {
+    x
+  }
+  if (length(taf_addr) == 0L) {
+    return(invisible(NULL))
+  }
+
+  needed <- taf_needed_counties(
+    taf_addr,
     year = year,
     version = version,
     zip_variants = zip_variants,
     zip_variant = zip_variant
   )
+  missing <- geocode_missing_taf_counties(
+    needed,
+    year = year,
+    version = version
+  )
 
   if (taf_install) {
-    taf_ensure_serial(
-      x,
+    geocode_install_missing_taf_counties(
+      missing,
       year = year,
       version = version,
-      zip_variants = zip_variants,
-      zip_variant = zip_variant,
       redownload = taf_redownload
     )
-    geocode_require_taf_installed(do.call(taf_missing_counties, missing_args))
+    geocode_require_taf_installed(geocode_missing_taf_counties(
+      needed,
+      year = year,
+      version = version
+    ))
   } else {
-    taf_warn_missing_counties(do.call(taf_missing_counties, missing_args))
+    taf_warn_missing_counties(missing)
   }
 
   invisible(NULL)
+}
+
+geocode_missing_taf_counties <- function(needed, year, version) {
+  if (nrow(needed) == 0L) {
+    return(needed)
+  }
+  manifest <- taf_read_county_zip_manifest(year = year, version = version)
+  missing_counties <- setdiff(
+    unique(needed$county_fips),
+    unique(manifest$county_fips)
+  )
+  needed[needed$county_fips %in% missing_counties, , drop = FALSE]
+}
+
+geocode_install_missing_taf_counties <- function(
+  missing,
+  year,
+  version,
+  redownload
+) {
+  if (nrow(missing) == 0L) {
+    return(invisible(missing))
+  }
+  taf_with_install_lock(year, version, {
+    for (county in unique(missing$county_fips)) {
+      taf_install(
+        county = county,
+        year = year,
+        version = version,
+        overwrite = FALSE,
+        redownload = redownload
+      )
+    }
+  })
+  invisible(missing)
 }
 
 geocode_require_taf_installed <- function(missing) {

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -139,8 +139,13 @@ geocode <- function(
     match_street_type = match_street_type,
     match_street_directional = match_street_directional
   )
+  progress_message <- if (progress) {
+    geocode_progress_timer()
+  } else {
+    NULL
+  }
   if (progress) {
-    geocode_progress_message(
+    progress_message(
       "preparing geocoding input (",
       geocode_format_count(length(x)),
       " addr)"
@@ -150,7 +155,7 @@ geocode <- function(
   taf_addr <- geocode_plan_taf_addr(plan)
   if (length(taf_addr) > 0L) {
     if (progress) {
-      geocode_progress_message(
+      progress_message(
         geocode_prepare_taf_progress_text(
           taf_addr,
           taf_install = taf_install,
@@ -168,17 +173,18 @@ geocode <- function(
       taf_redownload = taf_redownload
     )
     if (progress) {
-      geocode_progress_message("TIGER address feature file check complete")
+      progress_message("TIGER address feature file check complete")
     }
   }
   if (progress) {
-    geocode_progress_message(geocode_group_progress_text(plan$zip_groups))
+    progress_message(geocode_group_progress_text(plan$zip_groups))
   }
 
   gcd <- geocode_map(
     plan$zip_groups,
     geocode_zip,
     progress = progress,
+    progress_message = progress_message,
     offset = offset,
     name_phonetic_dist = name_phonetic_dist,
     name_fuzzy_dist = name_fuzzy_dist,
@@ -194,7 +200,7 @@ geocode <- function(
   )
   if (length(plan$missing_zip_idx) > 0L) {
     if (progress) {
-      geocode_progress_message(
+      progress_message(
         "adding no-match results for ",
         geocode_addr_count_text(length(plan$missing_zip_idx)),
         " without ZIP codes"
@@ -203,32 +209,37 @@ geocode <- function(
   }
   if (length(gcd) == 0L && length(plan$unique_addr) == 0L) {
     if (progress) {
-      geocode_progress_message("creating no-match geocode results")
+      progress_message("creating no-match geocode results")
     }
   }
   if (progress) {
-    geocode_progress_message(
+    progress_message(
       "combining geocode results from ",
       geocode_result_group_count_text(length(gcd))
     )
   }
-  gcd <- geocode_assemble_results(plan, gcd, progress = progress)
+  gcd <- geocode_assemble_results(
+    plan,
+    gcd,
+    progress = progress,
+    progress_message = progress_message
+  )
 
   if (add_s2_cell) {
     if (progress) {
-      geocode_progress_message("computing S2 cells")
+      progress_message("computing S2 cells")
     }
     gcd$s2_cell <- s2::as_s2_cell(gcd$matched_geography)
   }
   if (progress) {
-    geocode_progress_message(
+    progress_message(
       "restoring geocode output to ",
       geocode_input_addr_count_text(length(x))
     )
   }
   out <- gcd[plan$restore_idx, , drop = FALSE]
   if (progress) {
-    geocode_progress_message("geocoding complete")
+    progress_message("geocoding complete")
   }
   return(out)
 }
@@ -260,7 +271,12 @@ geocode_plan_taf_addr <- function(x) {
   x$unique_addr[x$non_missing_zip_idx]
 }
 
-geocode_assemble_results <- function(plan, results, progress = FALSE) {
+geocode_assemble_results <- function(
+  plan,
+  results,
+  progress = FALSE,
+  progress_message = geocode_progress_message
+) {
   n <- length(plan$unique_addr)
   if (n == 0L || length(results) == 0L) {
     return(geocode_no_match(plan$unique_addr))
@@ -275,7 +291,7 @@ geocode_assemble_results <- function(plan, results, progress = FALSE) {
   }
 
   if (progress) {
-    geocode_progress_message("validating geocode result groups")
+    progress_message("validating geocode result groups")
   }
   result_rows <- vector("list", length(results))
   names(result_rows) <- names(results)
@@ -290,7 +306,7 @@ geocode_assemble_results <- function(plan, results, progress = FALSE) {
   }
 
   if (progress) {
-    geocode_progress_message("concatenating geocode result columns")
+    progress_message("concatenating geocode result columns")
   }
   row_order <- unlist(result_rows, use.names = FALSE)
   matched_zipcode <- unlist(
@@ -321,7 +337,7 @@ geocode_assemble_results <- function(plan, results, progress = FALSE) {
   }
 
   if (progress) {
-    geocode_progress_message("reordering geocode result rows")
+    progress_message("reordering geocode result rows")
   }
   restore_unique_idx <- match(seq_len(n), row_order)
   if (anyNA(restore_unique_idx) || length(unique(row_order)) != n) {
@@ -415,15 +431,27 @@ geocode_check_result <- function(x, rows, zip) {
   invisible(x)
 }
 
-geocode_map <- function(x, FUN, progress, ...) {
+geocode_map <- function(
+  x,
+  FUN,
+  progress,
+  progress_message = geocode_progress_message,
+  ...
+) {
   if (length(x) == 0L) {
     return(list())
   }
   if (geocode_use_mirai()) {
     if (progress) {
-      geocode_progress_message(geocode_mirai_progress_text(x))
+      progress_message(geocode_mirai_progress_text(x))
     }
-    return(geocode_map_mirai(x, FUN, progress = progress, ...))
+    return(geocode_map_mirai(
+      x,
+      FUN,
+      progress = progress,
+      progress_message = progress_message,
+      ...
+    ))
   }
   if (progress) {
     return(lapply_pb(x, FUN, ...))
@@ -436,7 +464,13 @@ geocode_use_mirai <- function() {
     mirai::daemons_set()
 }
 
-geocode_map_mirai <- function(x, FUN, progress, ...) {
+geocode_map_mirai <- function(
+  x,
+  FUN,
+  progress,
+  progress_message = geocode_progress_message,
+  ...
+) {
   geocode_args <- list(...)
   load_dev <- geocode_load_dev_workers()
   package_path <- if (load_dev) {
@@ -455,12 +489,12 @@ geocode_map_mirai <- function(x, FUN, progress, ...) {
   )
   out <- geocode_collect_mirai(out, x, progress = progress)
   if (progress) {
-    geocode_progress_message("mirai workers complete; restoring geographies")
+    progress_message("mirai workers complete; restoring geographies")
   }
   geocode_check_parallel_results(out)
   out <- lapply(out, geocode_restore_parallel_result)
   if (progress) {
-    geocode_progress_message("mirai geocoding results restored")
+    progress_message("mirai geocoding results restored")
   }
   out
 }
@@ -700,6 +734,38 @@ geocode_progress_text <- function(zip, x_n, y_n) {
 geocode_progress_message <- function(...) {
   cat(..., "\n", sep = "")
   utils::flush.console()
+}
+
+geocode_progress_timer <- function() {
+  started <- proc.time()[["elapsed"]]
+  last <- started
+  function(...) {
+    now <- proc.time()[["elapsed"]]
+    step <- now - last
+    total <- now - started
+    last <<- now
+    geocode_progress_message(
+      ...,
+      " (+",
+      geocode_progress_duration_text(step),
+      "; total ",
+      geocode_progress_duration_text(total),
+      ")"
+    )
+  }
+}
+
+geocode_progress_duration_text <- function(x) {
+  if (x < 1) {
+    return(sprintf("%.2fs", x))
+  }
+  if (x < 10) {
+    return(sprintf("%.1fs", x))
+  }
+  if (x < 60) {
+    return(sprintf("%ss", floor(x)))
+  }
+  geocode_elapsed_text(x)
 }
 
 geocode_format_count <- function(x) {

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -231,21 +231,86 @@ geocode_map_mirai <- function(x, FUN, progress, ...) {
       load_dev = load_dev
     )
   )
-  out <- if (progress) {
-    out[.progress]
-  } else {
-    out[]
-  }
+  out <- geocode_collect_mirai(out, x, progress = progress)
   geocode_check_parallel_results(out)
   out <- lapply(out, geocode_restore_parallel_result)
   out
 }
 
-utils::globalVariables(".progress")
-
 geocode_load_dev_workers <- function() {
   requireNamespace("pkgload", quietly = TRUE) &&
     pkgload::is_dev_package("addr")
+}
+
+geocode_collect_mirai <- function(x, tasks, progress) {
+  if (!progress) {
+    return(x[])
+  }
+
+  total_groups <- length(x)
+  task_sizes <- lengths(tasks)
+  total_addr <- sum(task_sizes)
+  done <- rep(FALSE, total_groups)
+  out <- vector("list", total_groups)
+  names(out) <- names(x)
+  started <- proc.time()[["elapsed"]]
+  last_completed <- NA_integer_
+  last_update <- 0
+
+  geocode_mirai_status_update(
+    completed_groups = 0L,
+    total_groups = total_groups,
+    completed_addr = 0L,
+    total_addr = total_addr,
+    last_zip = NA_character_,
+    last_addr = NA_integer_,
+    elapsed = 0
+  )
+  on.exit(cat("\n"), add = TRUE)
+
+  while (!all(done)) {
+    resolved <- !vapply(x, mirai::unresolved, logical(1))
+    newly_done <- which(resolved & !done)
+    if (length(newly_done) > 0L) {
+      for (i in newly_done) {
+        out[[i]] <- x[[i]]$data
+      }
+      done[newly_done] <- TRUE
+      last_completed <- newly_done[[length(newly_done)]]
+    }
+
+    elapsed <- proc.time()[["elapsed"]] - started
+    should_update <- length(newly_done) > 0L ||
+      elapsed - last_update >= geocode_mirai_progress_interval()
+    if (should_update) {
+      last_update <- elapsed
+      last_zip <- if (is.na(last_completed)) {
+        NA_character_
+      } else {
+        names(x)[[last_completed]]
+      }
+      last_addr <- if (is.na(last_completed)) {
+        NA_integer_
+      } else {
+        task_sizes[[last_completed]]
+      }
+      geocode_mirai_status_update(
+        completed_groups = sum(done),
+        total_groups = total_groups,
+        completed_addr = sum(task_sizes[done]),
+        total_addr = total_addr,
+        last_zip = last_zip,
+        last_addr = last_addr,
+        elapsed = elapsed
+      )
+    }
+
+    if (!all(done)) {
+      Sys.sleep(0.1)
+    }
+  }
+
+  out
 }
 
 geocode_worker <- function(
@@ -451,6 +516,80 @@ geocode_mirai_progress_text <- function(x) {
     geocode_zip_group_count_text(length(x)),
     geocode_addr_count_text(sum(lengths(x)))
   )
+}
+
+geocode_mirai_status_update <- function(
+  completed_groups,
+  total_groups,
+  completed_addr,
+  total_addr,
+  last_zip,
+  last_addr,
+  elapsed
+) {
+  cat(
+    "\r\033[2K",
+    geocode_mirai_status_text(
+      completed_groups = completed_groups,
+      total_groups = total_groups,
+      completed_addr = completed_addr,
+      total_addr = total_addr,
+      last_zip = last_zip,
+      last_addr = last_addr,
+      elapsed = elapsed
+    ),
+    sep = ""
+  )
+  utils::flush.console()
+}
+
+geocode_mirai_status_text <- function(
+  completed_groups,
+  total_groups,
+  completed_addr,
+  total_addr,
+  last_zip,
+  last_addr,
+  elapsed
+) {
+  last_text <- if (is.na(last_zip) || is.na(last_addr)) {
+    "last completed: none yet"
+  } else {
+    sprintf(
+      "last completed: %s (%s)",
+      last_zip,
+      geocode_addr_count_text(last_addr)
+    )
+  }
+  sprintf(
+    "mirai geocoding: %s/%s ZIP groups complete; %s/%s unique addr complete; %s; elapsed %s",
+    geocode_format_count(completed_groups),
+    geocode_format_count(total_groups),
+    geocode_format_count(completed_addr),
+    geocode_format_count(total_addr),
+    last_text,
+    geocode_elapsed_text(elapsed)
+  )
+}
+
+geocode_elapsed_text <- function(x) {
+  if (x < 60) {
+    return(sprintf("%ss", floor(x)))
+  }
+  sprintf("%sm %02ds", floor(x / 60), floor(x %% 60))
+}
+
+geocode_mirai_progress_interval <- function() {
+  interval <- getOption("addr.geocode_mirai_progress_interval", 1)
+  if (length(interval) == 0L) {
+    return(1)
+  }
+  interval <- suppressWarnings(as.numeric(interval[[1]]))
+  if (is.na(interval) || interval <= 0) {
+    1
+  } else {
+    interval
+  }
 }
 
 geocode_addr_count_text <- function(n) {

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -627,12 +627,14 @@ geocode_zip <- function(
   }
 
   ref_exact <- taf_zip(zpcd, map = TRUE, year = year, version = version)
+  ref_exact_streets <- geocode_unique_ref_streets(ref_exact)
+  ref_exact_rng_idx <- geocode_ref_range_index(ref_exact)
   if (is.function(progress_callback)) {
     progress_callback(length(ref_exact$addr_street))
   }
   out$matched_street <- do.call(
     match_addr_street,
-    c(list(x = x@street, y = ref_exact$addr_street), street_match_args)
+    c(list(x = x@street, y = ref_exact_streets$addr_street), street_match_args)
   )
 
   no <- which(is.na(out$matched_street))
@@ -652,15 +654,19 @@ geocode_zip <- function(
       year = year,
       version = version
     )
+    ref_variant_streets <- geocode_unique_ref_streets(ref_variant)
     out$matched_street[no] <- do.call(
       match_addr_street,
-      c(list(x = x@street[no], y = ref_variant$addr_street), street_match_args)
+      c(
+        list(x = x@street[no], y = ref_variant_streets$addr_street),
+        street_match_args
+      )
     )
     out$matched_zipcode[no] <-
-      ref_variant[
+      ref_variant_streets[
         match(
-          as.character(out$matched_street[no]),
-          as.character(ref_variant$addr_street)
+          geocode_street_key(out$matched_street[no]),
+          geocode_street_key(ref_variant_streets$addr_street)
         ),
         "ZIP",
         drop = TRUE
@@ -668,39 +674,44 @@ geocode_zip <- function(
   } else if (length(no) != 0) {
     out$matched_zipcode[no] <- NA_character_
     ref_variant <- ref_exact[0, ]
+    ref_variant_streets <- geocode_unique_ref_streets(ref_variant)
   } else {
     ref_variant <- ref_exact[0, ]
+    ref_variant_streets <- geocode_unique_ref_streets(ref_variant)
   }
 
-  ref_rng <-
-    lapply(seq_along(x), \(.i) {
-      if (is.na(out$matched_zipcode[.i]) || is.na(out$matched_street[.i])) {
-        return(ref_exact[0, ])
-      }
-      if (out$matched_zipcode[.i] == zpcd) {
-        return(
-          ref_exact[
-            format(ref_exact$addr_street) == format(out$matched_street[.i]),
-          ]
-        )
-      } else {
-        return(
-          ref_variant[
-            format(ref_variant$addr_street) == format(out$matched_street[.i]) &
-              ref_variant$ZIP == out$matched_zipcode[.i],
-          ]
-        )
-      }
-    })
+  ref_variant_rng_idx <- geocode_ref_range_index(ref_variant)
 
   out$matched_geography <-
     lapply(seq_along(x), \(.i) {
       sn <- to_int(x@number@digits[.i])
-      if (is.na(sn) || nrow(ref_rng[[.i]]) == 0L) {
+      if (
+        is.na(sn) ||
+          is.na(out$matched_zipcode[.i]) ||
+          is.na(out$matched_street[.i])
+      ) {
+        return(s2::as_s2_geography(NA_character_))
+      }
+      if (out$matched_zipcode[.i] == zpcd) {
+        cand_rows <- geocode_ref_range_rows(
+          ref_exact_rng_idx,
+          out$matched_zipcode[.i],
+          out$matched_street[.i]
+        )
+        ref <- ref_exact
+      } else {
+        cand_rows <- geocode_ref_range_rows(
+          ref_variant_rng_idx,
+          out$matched_zipcode[.i],
+          out$matched_street[.i]
+        )
+        ref <- ref_variant
+      }
+      if (length(cand_rows) == 0L) {
         return(s2::as_s2_geography(NA_character_))
       }
       sn_par <- ifelse(sn %% 2 == 0, "E", "O")
-      cand0 <- ref_rng[[.i]]
+      cand0 <- ref[cand_rows, , drop = FALSE]
       has_range <- !is.na(cand0$FROMHN) & !is.na(cand0$TOHN)
       cand0$in_range <- has_range &
         sn >= pmin(cand0$FROMHN, cand0$TOHN) &
@@ -751,6 +762,35 @@ geocode_zip <- function(
     do.call(c, args = _)
 
   out
+}
+
+geocode_unique_ref_streets <- function(x) {
+  keep <- !duplicated(as.data.frame(x$addr_street, stringsAsFactors = FALSE))
+  x[keep, c("ZIP", "addr_street"), drop = FALSE]
+}
+
+geocode_ref_range_index <- function(x) {
+  if (nrow(x) == 0L) {
+    return(list())
+  }
+  split(seq_len(nrow(x)), geocode_ref_range_key(x$ZIP, x$addr_street))
+}
+
+geocode_ref_range_rows <- function(index, zipcode, street) {
+  rows <- index[[geocode_ref_range_key(zipcode, street)]]
+  if (is.null(rows)) {
+    integer()
+  } else {
+    rows
+  }
+}
+
+geocode_ref_range_key <- function(zipcode, street) {
+  paste(zipcode, geocode_street_key(street), sep = "\r")
+}
+
+geocode_street_key <- function(x) {
+  format(x)
 }
 
 validate_geocode_offset <- function(offset) {

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -186,15 +186,43 @@ geocode <- function(
     taf_check = FALSE
   )
   if (any(missing_zip)) {
+    if (progress) {
+      geocode_progress_message(
+        "adding no-match results for ",
+        geocode_addr_count_text(sum(missing_zip)),
+        " without ZIP codes"
+      )
+    }
     gcd <- c(gcd, list(missing_zip = geocode_no_match(xu[missing_zip])))
   }
   if (length(gcd) == 0L) {
+    if (progress) {
+      geocode_progress_message("creating no-match geocode results")
+    }
     gcd <- list(geocode_no_match(xu))
+  }
+  if (progress) {
+    geocode_progress_message(
+      "combining geocode results from ",
+      geocode_result_group_count_text(length(gcd))
+    )
   }
   gcd <- do.call(rbind, gcd)
 
+  if (progress) {
+    geocode_progress_message(
+      "restoring geocode output to ",
+      geocode_input_addr_count_text(length(x))
+    )
+  }
   out <- gcd[match(format(x), format(gcd$addr)), ]
+  if (progress) {
+    geocode_progress_message("computing S2 cells")
+  }
   out$s2_cell <- s2::as_s2_cell(out$matched_geography)
+  if (progress) {
+    geocode_progress_message("geocoding complete")
+  }
   return(out)
 }
 
@@ -237,8 +265,14 @@ geocode_map_mirai <- function(x, FUN, progress, ...) {
     )
   )
   out <- geocode_collect_mirai(out, x, progress = progress)
+  if (progress) {
+    geocode_progress_message("mirai workers complete; restoring geographies")
+  }
   geocode_check_parallel_results(out)
   out <- lapply(out, geocode_restore_parallel_result)
+  if (progress) {
+    geocode_progress_message("mirai geocoding results restored")
+  }
   out
 }
 
@@ -599,6 +633,18 @@ geocode_mirai_progress_interval <- function() {
 
 geocode_addr_count_text <- function(n) {
   paste(geocode_format_count(n), "unique addr")
+}
+
+geocode_input_addr_count_text <- function(n) {
+  paste(geocode_format_count(n), "input addr")
+}
+
+geocode_result_group_count_text <- function(n) {
+  sprintf(
+    "%s result %s",
+    geocode_format_count(n),
+    if (n == 1L) "group" else "groups"
+  )
 }
 
 geocode_zip_group_count_text <- function(n) {

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -41,6 +41,11 @@
 #' serially by default.
 #' At a lower level, grouping addr vectors by ZIP code and applying
 #' `geocode_zip()` facilitates more control (e.g., parallel processing).
+#' Before ZIP grouping, `geocode()` deduplicates formatted `addr` values
+#' internally and restores the output to the original input order and length.
+#' Exact duplicates therefore do not trigger repeated TAF reads, street
+#' matching, or range interpolation, so callers usually do not need to call
+#' `unique()` themselves for geocoding performance.
 #'
 #' If the mirai package is installed and mirai daemons have already been
 #' configured by the caller, `geocode()` uses them for ZIP-code-level

--- a/man/geocode.Rd
+++ b/man/geocode.Rd
@@ -127,6 +127,11 @@ with multiple ZIP codes by grouping them by ZIP code and processing
 serially by default.
 At a lower level, grouping addr vectors by ZIP code and applying
 \code{geocode_zip()} facilitates more control (e.g., parallel processing).
+Before ZIP grouping, \code{geocode()} deduplicates formatted \code{addr} values
+internally and restores the output to the original input order and length.
+Exact duplicates therefore do not trigger repeated TAF reads, street
+matching, or range interpolation, so callers usually do not need to call
+\code{unique()} themselves for geocoding performance.
 
 If the mirai package is installed and mirai daemons have already been
 configured by the caller, \code{geocode()} uses them for ZIP-code-level

--- a/man/geocode.Rd
+++ b/man/geocode.Rd
@@ -18,6 +18,7 @@ geocode(
   taf_install = TRUE,
   taf_redownload = FALSE,
   offset = 10L,
+  add_s2_cell = TRUE,
   progress = interactive()
 )
 
@@ -85,6 +86,10 @@ installing missing TAF counties?}
 
 \item{offset}{number of meters to offset geocode from street line}
 
+\item{add_s2_cell}{logical; add an \code{s2_cell} column computed from matched
+geographies? Defaults to \code{TRUE}; set to \code{FALSE} to skip this final
+computation.}
+
 \item{progress}{logical; show progress messages and a ZIP-code progress bar
 while geocoding?}
 
@@ -97,8 +102,9 @@ by \code{geocode()} after checking once for the full input vector.}
 \value{
 A tibble with columns \code{addr} (the input addr vector),
 \code{matched_zipcode} (character vector), \code{matched_street} (\code{addr_street}
-vector), \code{matched_geography} (\code{s2_geography} point vector), and \code{s2_cell}
-(\code{s2_cell} vector).
+vector), and \code{matched_geography} (\code{s2_geography} point vector). When
+\code{add_s2_cell = TRUE}, the tibble also includes \code{s2_cell} (\code{s2_cell}
+vector).
 }
 \description{
 \code{geocode()} geocodes addr vectors using Census TIGER address

--- a/man/geocode.Rd
+++ b/man/geocode.Rd
@@ -85,7 +85,8 @@ installing missing TAF counties?}
 
 \item{offset}{number of meters to offset geocode from street line}
 
-\item{progress}{logical; show a ZIP-code progress bar while geocoding?}
+\item{progress}{logical; show progress messages and a ZIP-code progress bar
+while geocoding?}
 
 \item{progress_callback}{optional callback used internally by \code{geocode()}
 to update progress after ZIP-code reference data is loaded}

--- a/man/geocode_table.Rd
+++ b/man/geocode_table.Rd
@@ -12,7 +12,7 @@ geocode_table(x)
 \value{
 A tibble with atomic columns suitable for JSON serialization.
 \code{geocode_table()} includes the input address, geocode stage, matched ZIP
-code, matched street, and S2 cell as character columns.
+code, matched street, and, when present, S2 cell as character columns.
 }
 \description{
 \code{geocode_table()} converts the rich output from \code{\link[=geocode]{geocode()}} to a flat table

--- a/tests/testthat/test-arg-validation.R
+++ b/tests/testthat/test-arg-validation.R
@@ -111,6 +111,10 @@ test_that("geocode validates progress argument", {
     "offset must be non-negative"
   )
   expect_error(
+    geocode(x, add_s2_cell = NA),
+    "add_s2_cell must be TRUE or FALSE"
+  )
+  expect_error(
     geocode(x, match_street_type = NA_character_),
     "match_street_type must be one of"
   )

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -528,6 +528,62 @@ test_that("geocode_zip respects zipcode variant controls", {
   expect_true(is.na(out_none$matched_street))
 })
 
+test_that("geocode_zip matches duplicate TAF street ranges once", {
+  matched_against <- NULL
+  local_mocked_bindings(
+    taf_zip = function(zipcode, map = TRUE, ...) {
+      tibble::tibble(
+        ZIP = rep("45219", 4),
+        addr_street = addr_street(
+          predirectional = rep("", 4),
+          premodifier = rep("", 4),
+          pretype = rep("", 4),
+          name = c("Main", "Main", "Elm", "Elm"),
+          posttype = c("St", "St", "St", "St"),
+          postdirectional = rep("", 4)
+        ),
+        side = c("L", "R", "L", "R"),
+        FROMHN = c(1L, 2L, 1L, 2L),
+        TOHN = c(99L, 100L, 99L, 100L),
+        PARITY = c("O", "E", "O", "E"),
+        OFFSET = c("", "", "", ""),
+        s2_geography = s2::as_s2_geography(
+          rep("LINESTRING (-84 39, -84.1 39.1)", 4)
+        )
+      )
+    },
+    match_addr_street = function(x, y, ...) {
+      matched_against <<- length(y)
+      y[match(format(x), format(y))]
+    }
+  )
+  x <- addr(
+    addr_number(digits = c("11", "12")),
+    addr_street(
+      predirectional = c("", ""),
+      premodifier = c("", ""),
+      pretype = c("", ""),
+      name = c("Main", "Main"),
+      posttype = c("St", "St"),
+      postdirectional = c("", "")
+    ),
+    addr_place(zipcode = c("45219", "45219"))
+  )
+
+  out <- geocode_zip(
+    x,
+    offset = 0,
+    zip_variants = FALSE,
+    taf_install = FALSE,
+    taf_check = FALSE
+  )
+
+  expect_equal(matched_against, 2L)
+  expect_equal(out$matched_zipcode, c("45219", "45219"))
+  expect_equal(format(out$matched_street), c("Main St", "Main St"))
+  expect_false(any(is.na(out$matched_geography)))
+})
+
 test_that("geocode_zip skips generated invalid zipcode variants", {
   taf_zip_calls <- list()
   local_mocked_bindings(

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -1029,24 +1029,27 @@ test_that("geocode uses mirai mapping when daemons are configured", {
   expect_true(used_mirai)
   expect_true(seen_progress)
   progress_text <- paste(progress_output, collapse = "\n")
-  expect_match(progress_text, "preparing geocoding input \\(2 addr\\)")
+  progress_text <- gsub("\033\\[[0-9;]*[[:alpha:]]", "", progress_text)
+  progress_text <- gsub("\r", "", progress_text, fixed = TRUE)
+  expect_match(progress_text, "preparing geocoding input \\(2 input addr")
+  expect_match(progress_text, "2 unique addr")
+  expect_match(progress_text, "2 ZIP groups")
   expect_match(
     progress_text,
     "checking TIGER address feature files for 2 ZIP codes plus ZIP variants"
   )
-  expect_match(progress_text, "grouped 2 unique addr into 2 ZIP groups")
-  expect_match(
-    progress_text,
-    "dispatching 2 ZIP groups across mirai workers \\(2 unique addr\\)"
-  )
-  expect_match(progress_text, "combining geocode results from 2 result groups")
   expect_match(progress_text, "validating geocode result groups")
   expect_match(progress_text, "concatenating geocode result columns")
   expect_match(progress_text, "reordering geocode result rows")
   expect_match(progress_text, "restoring geocode output to 2 input addr")
   expect_match(progress_text, "computing S2 cells")
-  expect_match(progress_text, "geocoding complete")
-  expect_match(progress_text, "\\(\\+[0-9.]+s; total [0-9.]+s\\)")
+  expect_match(progress_text, "\\(\\+([0-9.]+s|[0-9]+m [0-9]{2}s)\\)")
+  expect_false(grepl("; total", progress_text, fixed = TRUE))
+  expect_false(grepl("TIGER address feature file check complete", progress_text, fixed = TRUE))
+  expect_false(grepl("grouped ", progress_text, fixed = TRUE))
+  expect_false(grepl("dispatching", progress_text, fixed = TRUE))
+  expect_false(grepl("combining geocode results", progress_text, fixed = TRUE))
+  expect_false(grepl("geocoding complete", progress_text, fixed = TRUE))
 })
 
 test_that("geocode mirai status text reports counts without ETA", {

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -890,6 +890,29 @@ test_that("geocode uses mirai mapping when daemons are configured", {
   )
 })
 
+test_that("geocode mirai status text reports counts without ETA", {
+  status <- geocode_mirai_status_text(
+    completed_groups = 3L,
+    total_groups = 10L,
+    completed_addr = 25L,
+    total_addr = 200L,
+    last_zip = "45219",
+    last_addr = 7L,
+    elapsed = 62
+  )
+
+  expect_equal(
+    status,
+    paste(
+      "mirai geocoding: 3/10 ZIP groups complete;",
+      "25/200 unique addr complete;",
+      "last completed: 45219 (7 unique addr);",
+      "elapsed 1m 02s"
+    )
+  )
+  expect_false(grepl("ETA", status, fixed = TRUE))
+})
+
 test_that("geocode works with mirai daemons on voter addresses", {
   skip_if_not_installed("mirai")
   skip_if_not_installed("pkgload")

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -1040,9 +1040,13 @@ test_that("geocode uses mirai mapping when daemons are configured", {
     "dispatching 2 ZIP groups across mirai workers \\(2 unique addr\\)"
   )
   expect_match(progress_text, "combining geocode results from 2 result groups")
+  expect_match(progress_text, "validating geocode result groups")
+  expect_match(progress_text, "concatenating geocode result columns")
+  expect_match(progress_text, "reordering geocode result rows")
   expect_match(progress_text, "restoring geocode output to 2 input addr")
   expect_match(progress_text, "computing S2 cells")
   expect_match(progress_text, "geocoding complete")
+  expect_match(progress_text, "\\(\\+[0-9.]+s; total [0-9.]+s\\)")
 })
 
 test_that("geocode mirai status text reports counts without ETA", {

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -923,6 +923,10 @@ test_that("geocode uses mirai mapping when daemons are configured", {
     progress_text,
     "dispatching 2 ZIP groups across mirai workers \\(2 unique addr\\)"
   )
+  expect_match(progress_text, "combining geocode results from 2 result groups")
+  expect_match(progress_text, "restoring geocode output to 2 input addr")
+  expect_match(progress_text, "computing S2 cells")
+  expect_match(progress_text, "geocoding complete")
 })
 
 test_that("geocode mirai status text reports counts without ETA", {

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -325,6 +325,41 @@ test_that("geocode forwards street matching arguments to geocode_zip", {
   )
 })
 
+test_that("geocode deduplicates duplicate addr before ZIP geocoding", {
+  seen_lengths <- integer()
+  local_mocked_bindings(
+    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    geocode_zip = function(x, offset = 0L, ...) {
+      seen_lengths <<- c(seen_lengths, length(x))
+      tibble::tibble(
+        addr = x,
+        matched_zipcode = x@place@zipcode,
+        matched_street = x@street,
+        matched_geography = s2::as_s2_geography(
+          rep("POINT (-84.5 39.1)", length(x))
+        )
+      )
+    }
+  )
+  x <- addr(
+    addr_number(digits = c("1", "1", "2", "1")),
+    addr_street(
+      name = c("Main", "Main", "Elm", "Main"),
+      posttype = c("St", "St", "St", "St"),
+      map_posttype = FALSE
+    ),
+    addr_place(zipcode = rep("45219", 4))
+  )
+
+  out <- geocode(x, taf_install = FALSE, progress = FALSE)
+
+  expect_equal(seen_lengths, 2L)
+  expect_equal(nrow(out), 4L)
+  expect_equal(out$addr, x)
+  expect_equal(out$matched_zipcode, rep("45219", 4))
+  expect_equal(format(out$matched_street), format(x@street))
+})
+
 test_that("geocode_zip forwards street matching arguments to match_addr_street", {
   seen <- NULL
   local_mocked_bindings(

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -1,3 +1,34 @@
+test_geocode_needed_counties <- function(
+  county_fips = "39061",
+  ZIP = "45220",
+  source_zip = ZIP,
+  source_zip_variant = "exact"
+) {
+  tibble::tibble(
+    county_fips = county_fips,
+    ZIP = ZIP,
+    zip3 = substr(ZIP, 1, 3),
+    zip2 = substr(ZIP, 4, 5),
+    n_ranges = rep(10L, length(ZIP)),
+    source_zip = source_zip,
+    source_zip_variant = source_zip_variant
+  )
+}
+
+test_geocode_manifest <- function(
+  county_fips = character(),
+  ZIP = character()
+) {
+  tibble::tibble(
+    county_fips = county_fips,
+    ZIP = ZIP,
+    zip3 = substr(ZIP, 1, 3),
+    zip2 = substr(ZIP, 4, 5),
+    n_ranges = rep(10L, length(ZIP)),
+    installed_at = rep("2026-07-02T00:00:00Z", length(ZIP))
+  )
+}
+
 test_that("geocode returns non-matches for missing zipcodes", {
   x <- addr(
     addr_number(digits = c("1", "2")),
@@ -20,17 +51,8 @@ test_that("geocode returns non-matches for missing zipcodes", {
 
 test_that("geocode warns when taf_install is FALSE and needed counties are missing", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) {
-      tibble::tibble(
-        county_fips = "39061",
-        ZIP = "45220",
-        zip3 = "452",
-        zip2 = "20",
-        n_ranges = 10L,
-        source_zip = "45220",
-        source_zip_variant = "exact"
-      )
-    },
+    taf_needed_counties = function(...) test_geocode_needed_counties(),
+    taf_read_county_zip_manifest = function(...) test_geocode_manifest(),
     geocode_zip = function(x, offset = 0L, ...) {
       tibble::tibble(
         addr = x,
@@ -61,24 +83,17 @@ test_that("geocode installs and verifies TAF before ZIP geocoding", {
     taf_with_install_lock = function(year, version, expr) {
       eval(substitute(expr), parent.frame())
     },
-    taf_ensure = function(...) {
+    taf_install = function(...) {
       expect_false(read_started)
       installed <<- TRUE
-      invisible(taf_empty_needed_counties())
+      invisible("39061")
     },
-    taf_missing_counties = function(...) {
+    taf_needed_counties = function(...) test_geocode_needed_counties(),
+    taf_read_county_zip_manifest = function(...) {
       if (installed) {
-        return(taf_empty_needed_counties())
+        return(test_geocode_manifest("39061", "45220"))
       }
-      tibble::tibble(
-        county_fips = "39061",
-        ZIP = "45220",
-        zip3 = "452",
-        zip2 = "20",
-        n_ranges = 10L,
-        source_zip = "45220",
-        source_zip_variant = "exact"
-      )
+      test_geocode_manifest()
     },
     geocode_zip = function(x, offset = 0L, ...) {
       expect_true(installed)
@@ -110,18 +125,9 @@ test_that("geocode stops before ZIP geocoding when TAF remains missing", {
     taf_with_install_lock = function(year, version, expr) {
       eval(substitute(expr), parent.frame())
     },
-    taf_ensure = function(...) invisible(taf_empty_needed_counties()),
-    taf_missing_counties = function(...) {
-      tibble::tibble(
-        county_fips = "39061",
-        ZIP = "45220",
-        zip3 = "452",
-        zip2 = "20",
-        n_ranges = 10L,
-        source_zip = "45220",
-        source_zip_variant = "exact"
-      )
-    },
+    taf_install = function(...) invisible("39061"),
+    taf_needed_counties = function(...) test_geocode_needed_counties(),
+    taf_read_county_zip_manifest = function(...) test_geocode_manifest(),
     geocode_zip = function(...) {
       read_started <<- TRUE
       stop("should not read TAF ZIP files")
@@ -140,9 +146,57 @@ test_that("geocode stops before ZIP geocoding when TAF remains missing", {
   expect_false(read_started)
 })
 
+test_that("geocode computes TAF needs once for the top-level plan", {
+  needed_calls <- 0L
+  manifest_calls <- 0L
+  zip_calls <- 0L
+  local_mocked_bindings(
+    taf_needed_counties = function(x, ...) {
+      needed_calls <<- needed_calls + 1L
+      expect_equal(length(x), 2L)
+      test_geocode_needed_counties(
+        county_fips = c("39061", "39061"),
+        ZIP = c("45219", "45220")
+      )
+    },
+    taf_read_county_zip_manifest = function(...) {
+      manifest_calls <<- manifest_calls + 1L
+      test_geocode_manifest("39061", "45219")
+    },
+    geocode_zip = function(x, offset = 0L, ...) {
+      zip_calls <<- zip_calls + 1L
+      tibble::tibble(
+        addr = x,
+        matched_zipcode = x@place@zipcode,
+        matched_street = x@street,
+        matched_geography = s2::as_s2_geography(
+          rep("POINT (-84.5 39.1)", length(x))
+        )
+      )
+    }
+  )
+  x <- addr(
+    addr_number(digits = c("1", "2", "1")),
+    addr_street(
+      name = c("Main", "Elm", "Main"),
+      posttype = c("St", "St", "St"),
+      map_posttype = FALSE
+    ),
+    addr_place(zipcode = c("45219", "45220", "45219"))
+  )
+
+  out <- geocode(x, taf_install = FALSE, progress = FALSE)
+
+  expect_equal(needed_calls, 1L)
+  expect_equal(manifest_calls, 1L)
+  expect_equal(zip_calls, 2L)
+  expect_equal(nrow(out), 3L)
+  expect_equal(out$addr, x)
+})
+
 test_that("geocode keeps missing zipcode rows with geocoded rows", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_zip = function(x, offset = 0L, ...) {
       tibble::tibble(
         addr = x,
@@ -187,13 +241,13 @@ test_that("geocode_stage classifies staged geocode results", {
     name = c("Main", "Main", "Main", "Main", NA_character_, "Main"),
     posttype = c("St", "St", "St", "St", NA_character_, "St")
   )
-  s2_cell <- s2::as_s2_cell(c(
-    "808fbfffffffffff",
+  matched_geography <- s2::as_s2_geography(c(
+    "POINT (-84.5 39.1)",
     NA_character_,
-    "808fbfffffffffff",
+    "POINT (-84.5 39.1)",
     NA_character_,
     NA_character_,
-    "808fbfffffffffff"
+    "POINT (-84.5 39.1)"
   ))
   gcd <- tibble::tibble(
     addr = x,
@@ -206,7 +260,7 @@ test_that("geocode_stage classifies staged geocode results", {
       NA_character_
     ),
     matched_street = matched_street,
-    s2_cell = s2_cell
+    matched_geography = matched_geography
   )
 
   expect_equal(
@@ -231,10 +285,15 @@ test_that("geocode_table returns a JSON-safe flat table", {
     "808fbfffffffffff",
     NA_character_
   ))
+  matched_geography <- s2::as_s2_geography(c(
+    "POINT (-84.5 39.1)",
+    NA_character_
+  ))
   gcd <- tibble::tibble(
     addr = x,
     matched_zipcode = c("45220", NA_character_),
     matched_street = matched_street,
+    matched_geography = matched_geography,
     s2_cell = s2_cell
   )
 
@@ -263,10 +322,39 @@ test_that("geocode_table returns a JSON-safe flat table", {
   expect_false(any(vapply(out, inherits, logical(1), "s2_cell")))
 })
 
+test_that("geocode_table omits S2 cell when geocode output omits it", {
+  x <- as_addr(c(
+    "10 Main St Cincinnati OH 45220",
+    "11 Oak Rd Cincinnati OH 45221"
+  ))
+  matched_street <- addr_street(
+    name = c("Main", NA_character_),
+    posttype = c("St", NA_character_)
+  )
+  gcd <- tibble::tibble(
+    addr = x,
+    matched_zipcode = c("45220", NA_character_),
+    matched_street = matched_street,
+    matched_geography = s2::as_s2_geography(c(
+      "POINT (-84.5 39.1)",
+      NA_character_
+    ))
+  )
+
+  out <- geocode_table(gcd)
+
+  expect_equal(
+    names(out),
+    c("addr", "geocode_stage", "matched_zipcode", "matched_street")
+  )
+  expect_equal(out$geocode_stage, c("range", "none"))
+  expect_false("s2_cell" %in% names(out))
+})
+
 test_that("geocode forwards street matching arguments to geocode_zip", {
   seen <- NULL
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_zip = function(
       x,
       offset = 0L,
@@ -328,7 +416,7 @@ test_that("geocode forwards street matching arguments to geocode_zip", {
 test_that("geocode deduplicates duplicate addr before ZIP geocoding", {
   seen_lengths <- integer()
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_zip = function(x, offset = 0L, ...) {
       seen_lengths <<- c(seen_lengths, length(x))
       tibble::tibble(
@@ -358,6 +446,50 @@ test_that("geocode deduplicates duplicate addr before ZIP geocoding", {
   expect_equal(out$addr, x)
   expect_equal(out$matched_zipcode, rep("45219", 4))
   expect_equal(format(out$matched_street), format(x@street))
+})
+
+test_that("geocode can skip S2 cell output", {
+  local_mocked_bindings(
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
+    geocode_zip = function(x, offset = 0L, ...) {
+      tibble::tibble(
+        addr = x,
+        matched_zipcode = x@place@zipcode,
+        matched_street = x@street,
+        matched_geography = s2::as_s2_geography(
+          rep("POINT (-84.5 39.1)", length(x))
+        )
+      )
+    }
+  )
+  x <- addr(
+    addr_number(digits = c("1", "1", "2")),
+    addr_street(
+      name = c("Main", "Main", "Elm"),
+      posttype = c("St", "St", "St"),
+      map_posttype = FALSE
+    ),
+    addr_place(zipcode = rep("45219", 3))
+  )
+
+  out <- geocode(
+    x,
+    taf_install = FALSE,
+    add_s2_cell = FALSE,
+    progress = FALSE
+  )
+
+  expect_equal(nrow(out), 3L)
+  expect_equal(out$addr, x)
+  expect_false("s2_cell" %in% names(out))
+  expect_equal(
+    geocode_stage(out),
+    ordered(
+      rep("range", 3),
+      levels = c("none", "street_variant", "street", "range_variant", "range")
+    )
+  )
+  expect_false("s2_cell" %in% names(geocode_table(out)))
 })
 
 test_that("geocode_zip forwards street matching arguments to match_addr_street", {
@@ -407,17 +539,8 @@ test_that("geocode_zip forwards street matching arguments to match_addr_street",
 
 test_that("geocode_zip warns when taf_install is FALSE and needed counties are missing", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) {
-      tibble::tibble(
-        county_fips = "39061",
-        ZIP = "45220",
-        zip3 = "452",
-        zip2 = "20",
-        n_ranges = 10L,
-        source_zip = "45220",
-        source_zip_variant = "exact"
-      )
-    },
+    taf_needed_counties = function(...) test_geocode_needed_counties(),
+    taf_read_county_zip_manifest = function(...) test_geocode_manifest(),
     taf_zip = function(zipcode, map = TRUE, ...) {
       tibble::tibble(
         ZIP = zipcode,
@@ -452,23 +575,16 @@ test_that("geocode_zip serializes TAF install before reading ZIP files", {
       lock_used <<- TRUE
       eval(substitute(expr), parent.frame())
     },
-    taf_ensure = function(...) {
+    taf_install = function(...) {
       installed <<- TRUE
-      invisible(taf_empty_needed_counties())
+      invisible("39061")
     },
-    taf_missing_counties = function(...) {
+    taf_needed_counties = function(...) test_geocode_needed_counties(),
+    taf_read_county_zip_manifest = function(...) {
       if (installed) {
-        return(taf_empty_needed_counties())
+        return(test_geocode_manifest("39061", "45220"))
       }
-      tibble::tibble(
-        county_fips = "39061",
-        ZIP = "45220",
-        zip3 = "452",
-        zip2 = "20",
-        n_ranges = 10L,
-        source_zip = "45220",
-        source_zip_variant = "exact"
-      )
+      test_geocode_manifest()
     },
     taf_zip = function(zipcode, map = TRUE, ...) {
       expect_true(lock_used)
@@ -662,7 +778,7 @@ test_that("geocode_zip skips generated invalid zipcode variants", {
 
 test_that("geocode reports ZIP and address context for ZIP-level errors", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_use_mirai = function() FALSE,
     geocode_zip = function(...) {
       stop("boom", call. = FALSE)
@@ -838,7 +954,7 @@ test_that("geocode progress text shows ZIP and addr_street count", {
 
 test_that("geocode progress gets addr_street count from geocode_zip", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_zip = function(x, offset = 0L, progress_callback = NULL, ...) {
       progress_callback(4599L)
       tibble::tibble(
@@ -877,7 +993,7 @@ test_that("geocode uses mirai mapping when daemons are configured", {
   used_mirai <- FALSE
   seen_progress <- NULL
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_use_mirai = function() TRUE,
     geocode_map_mirai = function(x, FUN, progress, ...) {
       used_mirai <<- TRUE
@@ -1079,7 +1195,7 @@ test_that("geocode works with mirai daemons on voter addresses", {
 
 test_that("geocode falls back to the default progress bar when mirai is unavailable", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_use_mirai = function() FALSE,
     geocode_zip = function(x, offset = 0L, progress_callback = NULL, ...) {
       progress_callback(4599L)
@@ -1117,7 +1233,7 @@ test_that("geocode falls back to the default progress bar when mirai is unavaila
 
 test_that("geocode progress can be disabled", {
   local_mocked_bindings(
-    taf_missing_counties = function(...) taf_empty_needed_counties(),
+    taf_needed_counties = function(...) taf_empty_needed_counties(),
     geocode_zip = function(x, offset = 0L, progress_callback = NULL, ...) {
       tibble::tibble(
         addr = x,

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -840,11 +840,13 @@ test_that("geocode progress gets addr_street count from geocode_zip", {
 
 test_that("geocode uses mirai mapping when daemons are configured", {
   used_mirai <- FALSE
+  seen_progress <- NULL
   local_mocked_bindings(
     taf_missing_counties = function(...) taf_empty_needed_counties(),
     geocode_use_mirai = function() TRUE,
-    geocode_map_mirai = function(x, FUN, ...) {
+    geocode_map_mirai = function(x, FUN, progress, ...) {
       used_mirai <<- TRUE
+      seen_progress <<- progress
       lapply(x, FUN, ...)
     },
     geocode_zip = function(x, offset = 0L, progress_callback = NULL, ...) {
@@ -874,7 +876,18 @@ test_that("geocode uses mirai mapping when daemons are configured", {
     taf_install = FALSE
   )))
   expect_true(used_mirai)
-  expect_equal(progress_output, character())
+  expect_true(seen_progress)
+  progress_text <- paste(progress_output, collapse = "\n")
+  expect_match(progress_text, "preparing geocoding input \\(2 addr\\)")
+  expect_match(
+    progress_text,
+    "checking TIGER address feature files for 2 ZIP codes plus ZIP variants"
+  )
+  expect_match(progress_text, "grouped 2 unique addr into 2 ZIP groups")
+  expect_match(
+    progress_text,
+    "dispatching 2 ZIP groups across mirai workers \\(2 unique addr\\)"
+  )
 })
 
 test_that("geocode works with mirai daemons on voter addresses", {


### PR DESCRIPTION
- deduplicates `taf_zip()` street candidates before street matching so duplicate range rows do not inflate matching work
- replaces per-address copied range tibbles with a compact zip and street row index for interpolation
- builds one internal `geocode()` plan before ZIP dispatch so duplicate restoration, missing-ZIP handling, and ZIP grouping reuse the same integer indices
- reuses planned TAF needed-county rows for top-level install and warning checks instead of recomputing missing counties around worker dispatch
- assembles geocode output with one column-wise concatenate plus one reorder, avoiding repeated per-ZIP assignment into `addr_street` and `s2_geography` columns
- adds `add_s2_cell = TRUE` to let callers skip S2 cell creation, while computing S2 cells on unique geocode rows before duplicate expansion when enabled
- adds user-facing setup progress before input planning and TAF checks without standalone grouping or dispatch messages
- replaces mirai ETA progress with an addr-owned no-ETA status line showing completed ZIP groups, completed unique addresses, last completed ZIP, and elapsed time
