### PR TITLE
TIGER download improvements

### DIFF
--- a/R/tiger.R
+++ b/R/tiger.R
@@ -7,15 +7,101 @@ tiger_download <- function(x, overwrite = FALSE) {
     "overwrite must be length one" = length(overwrite) == 1L,
     "overwrite must not be missing" = !is.na(overwrite)
   )
-  tiger_url <- paste0("ftp://ftp2.census.gov/geo/tiger/", x)
+  tiger_url <- tiger_download_url(x)
   dest <- file.path(tools::R_user_dir("addr", "data"), x)
   dir.create(dirname(dest), showWarnings = FALSE, recursive = TRUE)
   if (overwrite || !file.exists(dest)) {
-    tf <- tempfile()
-    utils::download.file(tiger_url, tf)
-    file.copy(tf, dest, overwrite = TRUE)
+    tiger_download_to_cache(tiger_url, dest)
   }
   return(dest)
+}
+
+tiger_download_url <- function(x) {
+  paste0("https://www2.census.gov/geo/tiger/", x)
+}
+
+tiger_download_to_cache <- function(url, dest) {
+  tf <- tempfile(fileext = ".zip")
+  on.exit(unlink(tf, force = TRUE), add = TRUE)
+
+  tryCatch(
+    {
+      tiger_download_file(url, tf)
+      ok <- file.copy(tf, dest, overwrite = TRUE)
+      if (!ok) {
+        stop("failed to move completed download into place", call. = FALSE)
+      }
+    },
+    error = function(e) {
+      stop(
+        tiger_download_failure_message(
+          url = url,
+          dest = dest,
+          error_message = conditionMessage(e)
+        ),
+        call. = FALSE
+      )
+    }
+  )
+
+  invisible(dest)
+}
+
+tiger_download_file <- function(
+  url,
+  dest,
+  download_file = utils::download.file
+) {
+  stopifnot(
+    "url must be a character vector" = is.character(url),
+    "url must be length one" = length(url) == 1L,
+    "url must not be missing" = !is.na(url),
+    "dest must be a character vector" = is.character(dest),
+    "dest must be length one" = length(dest) == 1L,
+    "dest must not be missing" = !is.na(dest)
+  )
+
+  status <- download_file(url, dest, mode = "wb")
+  if (
+    !is.numeric(status) ||
+      length(status) != 1L ||
+      is.na(status) ||
+      status != 0L
+  ) {
+    stop("download returned status ", tiger_status_text(status), call. = FALSE)
+  }
+
+  invisible(dest)
+}
+
+tiger_status_text <- function(status) {
+  if (length(status) == 0L) {
+    return("<empty>")
+  }
+  paste(status, collapse = ", ")
+}
+
+tiger_download_failure_message <- function(url, dest, error_message) {
+  stopifnot(
+    "url must be a character vector" = is.character(url),
+    "url must be length one" = length(url) == 1L,
+    "url must not be missing" = !is.na(url),
+    "dest must be a character vector" = is.character(dest),
+    "dest must be length one" = length(dest) == 1L,
+    "dest must not be missing" = !is.na(dest),
+    "error_message must be a character vector" = is.character(error_message),
+    "error_message must be length one" = length(error_message) == 1L,
+    "error_message must not be missing" = !is.na(error_message)
+  )
+
+  paste0(
+    "failed to download TIGER file from `",
+    url,
+    "` to `",
+    dest,
+    "`: ",
+    error_message
+  )
 }
 
 #' Get names for tiger street ranges
@@ -25,7 +111,8 @@ tiger_download <- function(x, overwrite = FALSE) {
 #' TIGER primary feature names are read from compressed feature-name databases
 #' for each county and Census vintage.
 #' If not already present, compressed addrfeat (address feature) shapefiles are
-#' downloaded from the Census FTP site to the addr user data directory.
+#' downloaded from the Census TIGER HTTPS endpoint to the addr user data
+#' directory.
 #'
 #' When reading into R, the data is filtered to addressable MTFCCs
 #' (S1100, S1200, S1400, S1640) that have a name.
@@ -106,7 +193,7 @@ tiger_feat_names <- function(county, year, redownload = FALSE) {
 #' TIGER address features (street address ranges) are read from compressed
 #' addrfeat (address feature) shapefiles for each county and Census vintage.
 #' If not already present, compressed addrfeat shapefiles are downloaded from
-#' the Census FTP site to the addr user data directory.
+#' the Census TIGER HTTPS endpoint to the addr user data directory.
 #'
 #' When reading into R, the data is converted to one row per street side
 #' (`L`/`R`) for use by `taf_install()`.

--- a/man/tiger_addr_feat.Rd
+++ b/man/tiger_addr_feat.Rd
@@ -21,7 +21,7 @@ a tibble with \code{LINEARID}, \code{FULLNAME}, \code{side}, \code{ZIP},
 TIGER address features (street address ranges) are read from compressed
 addrfeat (address feature) shapefiles for each county and Census vintage.
 If not already present, compressed addrfeat shapefiles are downloaded from
-the Census FTP site to the addr user data directory.
+the Census TIGER HTTPS endpoint to the addr user data directory.
 
 When reading into R, the data is converted to one row per street side
 (\code{L}/\code{R}) for use by \code{taf_install()}.

--- a/man/tiger_feat_names.Rd
+++ b/man/tiger_feat_names.Rd
@@ -20,7 +20,8 @@ a tibble with unique \code{LINEARID} and \code{addr} columns
 TIGER primary feature names are read from compressed feature-name databases
 for each county and Census vintage.
 If not already present, compressed addrfeat (address feature) shapefiles are
-downloaded from the Census FTP site to the addr user data directory.
+downloaded from the Census TIGER HTTPS endpoint to the addr user data
+directory.
 
 When reading into R, the data is filtered to addressable MTFCCs
 (S1100, S1200, S1400, S1640) that have a name.

--- a/tests/testthat/test-tiger.R
+++ b/tests/testthat/test-tiger.R
@@ -3,9 +3,122 @@ test_that("can download files from tiger", {
   skip_on_cran()
   withr::local_envvar(list("R_USER_DATA_DIR" = tempfile()))
   dl_file <- tiger_download(
-    "TIGER2024/INTERNATIONALBOUNDARY/tl_2024_us_internationalboundary.zip"
+    "TIGER2024/FEATNAMES/tl_2024_39061_featnames.zip"
   )
   expect_true(file.exists(dl_file))
+})
+
+test_that("tiger_download_file uses binary mode and checks download status", {
+  dest <- tempfile(fileext = ".zip")
+  url <- "https://example.test/file.zip"
+  download_args <- NULL
+
+  tiger_download_file(
+    url,
+    dest,
+    download_file = function(url, dest, mode) {
+      download_args <<- list(url = url, dest = dest, mode = mode)
+      writeBin(charToRaw("zip"), dest)
+      0L
+    }
+  )
+
+  expect_equal(download_args$url, url)
+  expect_equal(download_args$dest, dest)
+  expect_equal(download_args$mode, "wb")
+  expect_equal(rawToChar(readBin(dest, "raw", n = 3L)), "zip")
+
+  expect_error(
+    tiger_download_file(
+      url,
+      tempfile(fileext = ".zip"),
+      download_file = function(url, dest, mode) 7L
+    ),
+    "download returned status 7",
+    fixed = TRUE
+  )
+})
+
+test_that("tiger_download uses HTTPS TIGER endpoint", {
+  data_root <- tempfile()
+  withr::local_envvar(list("R_USER_DATA_DIR" = data_root))
+
+  tiger_path <- "TIGER2024/INTERNATIONALBOUNDARY/tl_2024_us_internationalboundary.zip"
+  expected_url <- paste0("https://www2.census.gov/geo/tiger/", tiger_path)
+  expected_dest <- file.path(tools::R_user_dir("addr", "data"), tiger_path)
+  download_args <- NULL
+
+  local_mocked_bindings(
+    tiger_download_file = function(url, dest) {
+      download_args <<- list(url = url, dest = dest)
+      writeBin(charToRaw("zip"), dest)
+      invisible(dest)
+    }
+  )
+
+  dl_file <- tiger_download(tiger_path)
+
+  expect_equal(dl_file, expected_dest)
+  expect_equal(download_args$url, expected_url)
+  expect_false(identical(download_args$dest, expected_dest))
+  expect_true(file.exists(expected_dest))
+  expect_equal(rawToChar(readBin(expected_dest, "raw", n = 3L)), "zip")
+})
+
+test_that("tiger_download reports failed URL and destination", {
+  data_root <- tempfile()
+  withr::local_envvar(list("R_USER_DATA_DIR" = data_root))
+
+  tiger_path <- "TIGER2024/INTERNATIONALBOUNDARY/tl_2024_us_internationalboundary.zip"
+  expected_url <- paste0("https://www2.census.gov/geo/tiger/", tiger_path)
+  expected_dest <- file.path(tools::R_user_dir("addr", "data"), tiger_path)
+  temp_dest <- NULL
+
+  local_mocked_bindings(
+    tiger_download_file = function(url, dest) {
+      temp_dest <<- dest
+      writeBin(charToRaw("partial"), dest)
+      stop("network broke", call. = FALSE)
+    }
+  )
+
+  expect_error(
+    tiger_download(tiger_path),
+    paste0(
+      "failed to download TIGER file from `",
+      expected_url,
+      "` to `",
+      expected_dest,
+      "`: network broke"
+    ),
+    fixed = TRUE
+  )
+  expect_false(file.exists(temp_dest))
+  expect_false(file.exists(expected_dest))
+})
+
+test_that("tiger_download reuses cached files without downloading", {
+  data_root <- tempfile()
+  withr::local_envvar(list("R_USER_DATA_DIR" = data_root))
+
+  tiger_path <- "TIGER2024/INTERNATIONALBOUNDARY/tl_2024_us_internationalboundary.zip"
+  expected_dest <- file.path(tools::R_user_dir("addr", "data"), tiger_path)
+  dir.create(dirname(expected_dest), recursive = TRUE, showWarnings = FALSE)
+  writeBin(charToRaw("cached"), expected_dest)
+  downloaded <- FALSE
+
+  local_mocked_bindings(
+    tiger_download_file = function(url, dest) {
+      downloaded <<- TRUE
+      stop("should not download", call. = FALSE)
+    }
+  )
+
+  dl_file <- tiger_download(tiger_path)
+
+  expect_equal(dl_file, expected_dest)
+  expect_false(downloaded)
+  expect_equal(rawToChar(readBin(expected_dest, "raw", n = 6L)), "cached")
 })
 
 test_that("tiger_addr_feat() can download addr feat from tiger", {


### PR DESCRIPTION
- switch TIGER runtime downloads from `ftp://ftp2.census.gov/geo/tiger/` to `https://www2.census.gov/geo/tiger/`
- download TIGER ZIP archives in binary mode and check nonzero download statuses
- fail with a message that names the source URL and cache destination
- clean temporary download files on failure
- keep live-download tests guarded by `skip_if_offline()` and `skip_on_cran()`
- use new tiger zip for download smoke test
