### PR TITLE
add batch geocoder cli

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,6 +12,7 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^cli-tests$
 ^inst\.csv$
 ^diagrams$
 ^Containerfile$

--- a/Containerfile
+++ b/Containerfile
@@ -84,6 +84,8 @@ RUN echo "options(repos = c(CRAN = 'https://p3m.dev/cran/__linux__/manylinux_2_2
 
 COPY --from=builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
 
+RUN Rscript -e 'file.symlink(system.file("exec", "addr-geocode", package = "addr"), "/usr/local/bin/addr-geocode")'
+
 ENV R_USER_DATA_DIR=/opt/addr-data
 
 RUN useradd --create-home --shell /bin/bash addr \

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: addr
 Title: Clean, Parse, Harmonize, Match, and Geocode Messy Real-World US Addresses
-Version: 1.2.0
+Version: 1.3.0
 Authors@R: 
     c(person("Cole", "Brokamp", email = "cole@colebrokamp.com", role = c("aut", "cre")),
       person("Erika", "Manning", role = c("aut")))

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,20 @@ default:
 build:
     container build -f "$PWD/Containerfile" -t addr:local .
 
+# Run local CLI tests outside R CMD check.
+test-cli:
+    Rscript cli-tests/test-addr-geocode.R
+
+# Build the local image and smoke-test the container entrypoint.
+test-container: build
+    @tmp="$(mktemp -d)" ; \
+    trap 'rm -rf "$tmp"' EXIT ; \
+    mkdir -p "$tmp/work" "$tmp/data" "$tmp/tmp" ; \
+    TMP_WORK="$tmp/work" Rscript -e 'write.csv(data.frame(id = 1:2, address = c(NA_character_, NA_character_)), file = file.path(Sys.getenv("TMP_WORK"), "addresses.csv"), row.names = FALSE, na = "")' ; \
+    container run --rm -v "$tmp/work:/work" -v "$tmp/data:/opt/addr-data" -v "$tmp/tmp:/tmp" addr:local addr-geocode --input /work/addresses.csv ; \
+    version="$(Rscript -e 'cat(read.dcf("DESCRIPTION", "Version"))')" ; \
+    TMP_WORK="$tmp/work" ADDR_VERSION="$version" Rscript -e 'out <- file.path(Sys.getenv("TMP_WORK"), sprintf("addresses__addr-v%s__geocoded.csv", Sys.getenv("ADDR_VERSION"))); stopifnot(file.exists(out)); d <- read.csv(out, check.names = FALSE); stopifnot(nrow(d) == 2L); stopifnot(all(c("addr_geocode_stage", "addr_matched_zipcode", "addr_matched_street", "addr_longitude", "addr_latitude", "addr_s2_cell") %in% names(d))); print(d)'
+
 # Run the local addr image with its default command.
 run:
     @addr_data_dir="$(Rscript -e 'cat(tools::R_user_dir("addr", "data"))')" ; \

--- a/README.md
+++ b/README.md
@@ -47,33 +47,71 @@ Installing addr from GitHub requires a working [Rust](https://rust-lang.org/lear
 An OCI-compatible runtime image with R and addr installed is published to the GitHub Container Registry:
 
 ```sh
-docker pull ghcr.io/geomarker-io/addr:latest
-docker run --rm -it ghcr.io/geomarker-io/addr:latest
+docker pull ghcr.io/geomarker-io/addr:v1.2.0
+docker run --rm -it ghcr.io/geomarker-io/addr:v1.2.0
 ```
 
-The `latest` tag tracks the most recent published GitHub release.
-Release images are also tagged with the release tag, for example `ghcr.io/geomarker-io/addr:v1.2.0`.
+Container release tags mirror addr package release tags.
+For reproducible work, use a specific release tag such as `ghcr.io/geomarker-io/addr:v1.2.0`.
 
 The image does not include or pre-install TIGER/Line or National Address Database data.
 Runtime data uses the standard addr user data directory under `/opt/addr-data/R/addr`.
 Mount `/opt/addr-data` when you want downloads or derived data to persist across runs:
 
 ```sh
-docker run --rm -it -v addr-data:/opt/addr-data ghcr.io/geomarker-io/addr:latest
+docker run --rm -it -v addr-data:/opt/addr-data ghcr.io/geomarker-io/addr:v1.2.0
 ```
 
-On systems that use Apptainer, pull the same OCI image and bind a host directory directly to `/opt/addr-data`.
-Prefer `--cleanenv` and `--contain` so the container does not inherit host R environment variables, home-directory data, or temporary directories:
+#### Batch geocoding on a cluster
+
+The container includes an `addr-geocode` command for CSV or parquet files with a column named exactly `address`.
+The command writes a deterministic output file next to the input, matching the input file type and appending TIGER range geocoding columns.
+On systems that use Apptainer, pull a release-tagged image and bind user-specific scratch directories for persistent addr data and temporary files:
 
 ```sh
-mkdir -p "$HOME/addr-data"
-apptainer pull addr_latest.sif docker://ghcr.io/geomarker-io/addr:latest
-apptainer shell --cleanenv --contain \
-  --bind "$HOME/addr-data:/opt/addr-data" \
-  addr_latest.sif
+apptainer pull addr_v1.2.0.sif docker://ghcr.io/geomarker-io/addr:v1.2.0
+
+mkdir -p /scratch/<cchmc-user>/addr-data /scratch/<cchmc-user>/addr-tmp
+
+apptainer exec --cleanenv --contain \
+  --bind /scratch/<cchmc-user>/addr-data:/opt/addr-data \
+  --bind /scratch/<cchmc-user>/addr-tmp:/tmp \
+  --bind "$PWD:/work" \
+  addr_v1.2.0.sif \
+  addr-geocode \
+    --input /work/addresses.csv
 ```
 
-For local image development, use `just build` and `just run` with the `container` CLI.
+For example, Cole's CCHMC username is `broeg1`, so his scratch directories use `/scratch/broeg1/`:
+
+```sh
+mkdir -p /scratch/broeg1/addr-data /scratch/broeg1/addr-tmp
+```
+
+Use `--cleanenv` and `--contain` so the container does not inherit host R environment variables, home-directory data, or temporary directories.
+
+For local R installations, run the installed script from the shell:
+
+```sh
+Rscript "$(Rscript -e 'cat(system.file("exec", "addr-geocode", package = "addr"))')" \
+  --input addresses.csv
+```
+
+You can also create a one-time shell symlink:
+
+```sh
+mkdir -p "$HOME/.local/bin"
+ln -s "$(Rscript -e 'cat(system.file("exec", "addr-geocode", package = "addr"))')" \
+  "$HOME/.local/bin/addr-geocode"
+```
+
+Then run:
+
+```sh
+addr-geocode --input addresses.csv
+```
+
+For local image development, use `just build`, `just run`, and `just test-container` with the `container` CLI.
 The `just run` target resolves `tools::R_user_dir("addr", "data")` with the local R installation and mounts that directory into the container when it already exists.
 
 ## Getting started

--- a/cli-tests/test-addr-geocode.R
+++ b/cli-tests/test-addr-geocode.R
@@ -1,0 +1,198 @@
+script <- file.path(getwd(), "inst", "exec", "addr-geocode")
+
+assert <- function(x, message) {
+  if (!isTRUE(x)) {
+    stop(message, call. = FALSE)
+  }
+}
+
+expect_error <- function(expr, pattern) {
+  err <- tryCatch(
+    {
+      force(expr)
+      NULL
+    },
+    error = identity
+  )
+  if (is.null(err)) {
+    stop("expected an error", call. = FALSE)
+  }
+  if (!grepl(pattern, conditionMessage(err))) {
+    stop(
+      sprintf(
+        "error did not match %s: %s",
+        pattern,
+        conditionMessage(err)
+      ),
+      call. = FALSE
+    )
+  }
+  invisible(err)
+}
+
+Sys.setenv(ADDR_GEOCODE_CLI_SOURCE_ONLY = "1")
+source(script)
+
+tmp <- tempfile("addr-geocode-cli-")
+dir.create(tmp)
+on.exit(unlink(tmp, recursive = TRUE, force = TRUE), add = TRUE)
+
+opts <- addr_geocode_cli_parse_args(c(
+  "--input",
+  "addresses.csv",
+  "--workers",
+  "2",
+  "--taf-year=2025",
+  "--overwrite"
+))
+assert(identical(opts$input, "addresses.csv"), "input option was not parsed")
+assert(identical(opts$workers, 2L), "workers option was not parsed")
+assert(isTRUE(opts$overwrite), "overwrite option was not parsed")
+
+expect_error(
+  addr_geocode_cli_parse_args(character()),
+  "--input is required"
+)
+expect_error(
+  addr_geocode_cli_parse_args(c("--input", "x.csv", "--address-column", "addr")),
+  "unknown option"
+)
+
+out_path <- addr_geocode_cli_output_path(
+  file.path(tmp, "addresses.csv"),
+  version = "1.2.0"
+)
+assert(
+  identical(basename(out_path), "addresses__addr-v1.2.0__geocoded.csv"),
+  "csv output path was not deterministic"
+)
+
+parquet_out_path <- addr_geocode_cli_output_path(
+  file.path(tmp, "addresses.parquet"),
+  version = "1.2.0"
+)
+assert(
+  identical(
+    basename(parquet_out_path),
+    "addresses__addr-v1.2.0__geocoded.parquet"
+  ),
+  "parquet output path was not deterministic"
+)
+
+input <- data.frame(
+  id = 1:2,
+  address = c("10 Main St Cincinnati OH 45220", "No ZIP"),
+  stringsAsFactors = FALSE
+)
+addr_geocode_cli_validate_input(input)
+
+expect_error(
+  addr_geocode_cli_validate_input(data.frame(id = 1L)),
+  "column named exactly `address`"
+)
+expect_error(
+  addr_geocode_cli_validate_input(data.frame(
+    address = "x",
+    addr_geocode_stage = "none"
+  )),
+  "output column"
+)
+
+csv_path <- file.path(tmp, "addresses.csv")
+utils::write.csv(input, csv_path, row.names = FALSE)
+csv_in <- addr_geocode_cli_read(csv_path)
+assert(identical(names(csv_in), names(input)), "csv names were not preserved")
+csv_out <- addr_geocode_cli_output_path(csv_path, version = "1.2.0")
+addr_geocode_cli_write(
+  cbind(csv_in, addr_geocode_cli_empty_output(nrow(csv_in))),
+  csv_out
+)
+assert(file.exists(csv_out), "csv output was not written")
+
+if (requireNamespace("nanoparquet", quietly = TRUE)) {
+  parquet_path <- file.path(tmp, "addresses.parquet")
+  nanoparquet::write_parquet(input, parquet_path)
+  parquet_in <- addr_geocode_cli_read(parquet_path)
+  assert(
+    identical(names(parquet_in), names(input)),
+    "parquet names were not preserved"
+  )
+  parquet_out <- addr_geocode_cli_output_path(parquet_path, version = "1.2.0")
+  addr_geocode_cli_write(
+    cbind(parquet_in, addr_geocode_cli_empty_output(nrow(parquet_in))),
+    parquet_out
+  )
+  assert(file.exists(parquet_out), "parquet output was not written")
+}
+
+gcd <- tibble::tibble(
+  addr = addr::as_addr(c(
+    "10 Main St Cincinnati OH 45220",
+    "11 Oak Rd Cincinnati OH 45221",
+    NA_character_
+  )),
+  matched_zipcode = c("45220", "45221", NA_character_),
+  matched_street = addr::addr_street(
+    name = c("Main", "Oak", NA_character_),
+    posttype = c("St", "Rd", NA_character_)
+  ),
+  matched_geography = s2::as_s2_geography(c(
+    "POINT (-84.5 39.1)",
+    NA_character_,
+    NA_character_
+  )),
+  s2_cell = s2::as_s2_cell(s2::as_s2_geography(c(
+    "POINT (-84.5 39.1)",
+    NA_character_,
+    NA_character_
+  )))
+)
+flat <- addr_geocode_cli_flatten(gcd)
+assert(
+  identical(
+    names(flat),
+    c(
+      "addr_geocode_stage",
+      "addr_matched_zipcode",
+      "addr_matched_street",
+      "addr_longitude",
+      "addr_latitude",
+      "addr_s2_cell"
+    )
+  ),
+  "flattened output names are wrong"
+)
+assert(
+  identical(flat$addr_geocode_stage, c("range", "street", "none")),
+  "geocode stage flattening failed"
+)
+assert(identical(flat$addr_longitude[[1]], -84.5), "longitude was not added")
+assert(is.na(flat$addr_latitude[[2]]), "missing latitude was not preserved")
+
+run_input <- file.path(tmp, "local.csv")
+utils::write.csv(
+  data.frame(id = 1:2, address = c(NA_character_, NA_character_)),
+  run_input,
+  row.names = FALSE,
+  na = ""
+)
+Sys.unsetenv("ADDR_GEOCODE_CLI_SOURCE_ONLY")
+run_out <- system2(
+  file.path(R.home("bin"), "Rscript"),
+  c(script, "--input", run_input, "--data-dir", file.path(tmp, "addr-data")),
+  stdout = TRUE,
+  stderr = TRUE
+)
+status <- attr(run_out, "status")
+if (is.null(status)) {
+  status <- 0L
+}
+assert(identical(status, 0L), paste(run_out, collapse = "\n"))
+assert(
+  any(grepl("preparing geocoding input", run_out, fixed = TRUE)),
+  "local Rscript invocation did not emit geocode progress"
+)
+expected_run_output <- addr_geocode_cli_output_path(run_input)
+assert(file.exists(expected_run_output), "local Rscript invocation failed")
+
+cat("addr-geocode CLI tests passed\n")

--- a/inst/exec/addr-geocode
+++ b/inst/exec/addr-geocode
@@ -1,0 +1,316 @@
+#!/usr/bin/env Rscript
+
+addr_geocode_cli_usage <- function() {
+  paste(
+    "Usage:",
+    "  addr-geocode --input PATH [--output-dir DIR] [--workers N] [--taf-year YEAR] [--data-dir DIR] [--overwrite]",
+    "",
+    "Input:",
+    "  PATH must be a .csv or .parquet file containing a column named exactly `address`.",
+    "",
+    "Output:",
+    "  Writes one geocoded file matching the input file type. The output file",
+    "  name is deterministic and includes the installed addr package version.",
+    sep = "\n"
+  )
+}
+
+addr_geocode_cli_stop <- function(...) {
+  stop(paste0(...), call. = FALSE)
+}
+
+addr_geocode_cli_option_name <- function(x) {
+  sub("^--", "", x)
+}
+
+addr_geocode_cli_parse_args <- function(args) {
+  opts <- list(
+    input = NULL,
+    output_dir = NULL,
+    workers = 1L,
+    taf_year = "2025",
+    data_dir = NULL,
+    overwrite = FALSE,
+    help = FALSE
+  )
+
+  value_options <- c(
+    "input",
+    "output-dir",
+    "workers",
+    "taf-year",
+    "data-dir"
+  )
+  flag_options <- c("overwrite", "help")
+
+  i <- 1L
+  while (i <= length(args)) {
+    arg <- args[[i]]
+    if (arg %in% c("-h", "--help")) {
+      opts$help <- TRUE
+      i <- i + 1L
+      next
+    }
+    if (!startsWith(arg, "--")) {
+      addr_geocode_cli_stop("unexpected positional argument: ", arg)
+    }
+
+    if (grepl("=", arg, fixed = TRUE)) {
+      parts <- strsplit(arg, "=", fixed = TRUE)[[1]]
+      name <- addr_geocode_cli_option_name(parts[[1]])
+      value <- paste(parts[-1], collapse = "=")
+    } else {
+      name <- addr_geocode_cli_option_name(arg)
+      value <- NULL
+    }
+
+    if (name %in% flag_options) {
+      if (!is.null(value) && nzchar(value)) {
+        addr_geocode_cli_stop("--", name, " does not take a value")
+      }
+      opts[[gsub("-", "_", name)]] <- TRUE
+      i <- i + 1L
+      next
+    }
+
+    if (!name %in% value_options) {
+      addr_geocode_cli_stop("unknown option: --", name)
+    }
+
+    if (is.null(value)) {
+      if (i == length(args) || startsWith(args[[i + 1L]], "--")) {
+        addr_geocode_cli_stop("--", name, " requires a value")
+      }
+      value <- args[[i + 1L]]
+      i <- i + 2L
+    } else {
+      i <- i + 1L
+    }
+
+    opts[[gsub("-", "_", name)]] <- value
+  }
+
+  if (!opts$help && is.null(opts$input)) {
+    addr_geocode_cli_stop("--input is required\n\n", addr_geocode_cli_usage())
+  }
+
+  workers <- suppressWarnings(as.integer(opts$workers))
+  if (length(workers) != 1L || is.na(workers) || workers < 1L) {
+    addr_geocode_cli_stop("--workers must be a positive integer")
+  }
+  opts$workers <- workers
+
+  opts
+}
+
+addr_geocode_cli_file_format <- function(path) {
+  ext <- tolower(tools::file_ext(path))
+  if (identical(ext, "csv")) {
+    return("csv")
+  }
+  if (identical(ext, "parquet")) {
+    return("parquet")
+  }
+  addr_geocode_cli_stop(
+    "unsupported input file type: .",
+    ext,
+    "; expected .csv or .parquet"
+  )
+}
+
+addr_geocode_cli_read <- function(path) {
+  format <- addr_geocode_cli_file_format(path)
+  if (identical(format, "csv")) {
+    return(utils::read.csv(
+      path,
+      check.names = FALSE,
+      stringsAsFactors = FALSE
+    ))
+  }
+
+  if (!requireNamespace("nanoparquet", quietly = TRUE)) {
+    addr_geocode_cli_stop(
+      "nanoparquet is required to read and write parquet files"
+    )
+  }
+  as.data.frame(nanoparquet::read_parquet(path), stringsAsFactors = FALSE)
+}
+
+addr_geocode_cli_write <- function(x, path) {
+  format <- addr_geocode_cli_file_format(path)
+  if (identical(format, "csv")) {
+    utils::write.csv(x, path, row.names = FALSE, na = "")
+    return(invisible(path))
+  }
+
+  if (!requireNamespace("nanoparquet", quietly = TRUE)) {
+    addr_geocode_cli_stop(
+      "nanoparquet is required to read and write parquet files"
+    )
+  }
+  nanoparquet::write_parquet(x, path)
+  invisible(path)
+}
+
+addr_geocode_cli_output_path <- function(input, output_dir = NULL, version = NULL) {
+  input <- normalizePath(input, mustWork = FALSE)
+  input_dir <- dirname(input)
+  if (is.null(output_dir)) {
+    output_dir <- input_dir
+  }
+  if (is.null(version)) {
+    version <- as.character(utils::packageVersion("addr"))
+  }
+  ext <- tolower(tools::file_ext(input))
+  stem <- tools::file_path_sans_ext(basename(input))
+  version <- gsub("[^A-Za-z0-9._-]+", "-", version)
+  file.path(
+    output_dir,
+    sprintf("%s__addr-v%s__geocoded.%s", stem, version, ext)
+  )
+}
+
+addr_geocode_cli_validate_input <- function(x) {
+  if (!is.data.frame(x)) {
+    addr_geocode_cli_stop("input must be a data frame")
+  }
+  if (anyDuplicated(names(x))) {
+    addr_geocode_cli_stop("input contains duplicate column names")
+  }
+  if (!"address" %in% names(x)) {
+    addr_geocode_cli_stop("input must contain a column named exactly `address`")
+  }
+
+  output_names <- c(
+    "addr_geocode_stage",
+    "addr_matched_zipcode",
+    "addr_matched_street",
+    "addr_longitude",
+    "addr_latitude",
+    "addr_s2_cell"
+  )
+  conflicts <- intersect(names(x), output_names)
+  if (length(conflicts) > 0L) {
+    addr_geocode_cli_stop(
+      "input already contains output column name",
+      if (length(conflicts) == 1L) "" else "s",
+      ": ",
+      paste(conflicts, collapse = ", ")
+    )
+  }
+
+  invisible(x)
+}
+
+addr_geocode_cli_flatten <- function(geocoded) {
+  table <- addr::geocode_table(geocoded)
+  data.frame(
+    addr_geocode_stage = table$geocode_stage,
+    addr_matched_zipcode = table$matched_zipcode,
+    addr_matched_street = table$matched_street,
+    addr_longitude = s2::s2_x(geocoded$matched_geography),
+    addr_latitude = s2::s2_y(geocoded$matched_geography),
+    addr_s2_cell = table$s2_cell,
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+}
+
+addr_geocode_cli_empty_output <- function(n = 0L) {
+  data.frame(
+    addr_geocode_stage = rep(NA_character_, n),
+    addr_matched_zipcode = rep(NA_character_, n),
+    addr_matched_street = rep(NA_character_, n),
+    addr_longitude = rep(NA_real_, n),
+    addr_latitude = rep(NA_real_, n),
+    addr_s2_cell = rep(NA_character_, n),
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+}
+
+addr_geocode_cli_geocode <- function(address, taf_year, workers) {
+  if (length(address) == 0L) {
+    return(addr_geocode_cli_empty_output())
+  }
+
+  if (workers > 1L) {
+    if (!requireNamespace("mirai", quietly = TRUE)) {
+      addr_geocode_cli_stop("--workers greater than 1 requires mirai")
+    }
+    mirai::daemons(workers)
+    on.exit(mirai::daemons(0), add = TRUE)
+  }
+
+  geocoded <- addr::geocode(
+    addr::as_addr(as.character(address)),
+    year = taf_year,
+    progress = TRUE
+  )
+  addr_geocode_cli_flatten(geocoded)
+}
+
+addr_geocode_cli_main <- function(args = commandArgs(trailingOnly = TRUE)) {
+  opts <- addr_geocode_cli_parse_args(args)
+  if (opts$help) {
+    cat(addr_geocode_cli_usage(), "\n", sep = "")
+    return(invisible(NULL))
+  }
+
+  if (!is.null(opts$data_dir)) {
+    dir.create(opts$data_dir, recursive = TRUE, showWarnings = FALSE)
+    Sys.setenv(R_USER_DATA_DIR = normalizePath(opts$data_dir, mustWork = TRUE))
+  }
+
+  if (!requireNamespace("addr", quietly = TRUE)) {
+    addr_geocode_cli_stop("the addr package is required")
+  }
+  if (!requireNamespace("s2", quietly = TRUE)) {
+    addr_geocode_cli_stop("the s2 package is required")
+  }
+
+  input <- normalizePath(opts$input, mustWork = TRUE)
+  output <- addr_geocode_cli_output_path(
+    input,
+    output_dir = opts$output_dir
+  )
+  output_dir <- dirname(output)
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  output <- normalizePath(output, mustWork = FALSE)
+
+  if (file.exists(output) && !opts$overwrite) {
+    addr_geocode_cli_stop(
+      "output already exists: ",
+      output,
+      "; use --overwrite to replace it"
+    )
+  }
+
+  data <- addr_geocode_cli_read(input)
+  addr_geocode_cli_validate_input(data)
+  geocoded <- addr_geocode_cli_geocode(
+    data$address,
+    taf_year = opts$taf_year,
+    workers = opts$workers
+  )
+  out <- cbind(data, geocoded, stringsAsFactors = FALSE)
+  addr_geocode_cli_write(out, output)
+  message("wrote: ", output)
+  invisible(output)
+}
+
+# CLI tests source this file to exercise helper functions without running main.
+# Normal shell and container invocations leave this unset.
+if (!nzchar(Sys.getenv("ADDR_GEOCODE_CLI_SOURCE_ONLY"))) {
+  status <- tryCatch(
+    {
+      addr_geocode_cli_main()
+      0L
+    },
+    error = function(err) {
+      message("addr-geocode: ", conditionMessage(err))
+      1L
+    }
+  )
+  quit(save = "no", status = status)
+}

--- a/inst/exec/addr-geocode
+++ b/inst/exec/addr-geocode
@@ -19,6 +19,18 @@ addr_geocode_cli_stop <- function(...) {
   stop(paste0(...), call. = FALSE)
 }
 
+addr_geocode_cli_suppress_warnings <- function(expr) {
+  withCallingHandlers(
+    expr,
+    warning = function(wrn) {
+      restart <- findRestart("muffleWarning")
+      if (!is.null(restart)) {
+        invokeRestart(restart)
+      }
+    }
+  )
+}
+
 addr_geocode_cli_option_name <- function(x) {
   sub("^--", "", x)
 }
@@ -242,8 +254,12 @@ addr_geocode_cli_geocode <- function(address, taf_year, workers) {
     on.exit(mirai::daemons(0), add = TRUE)
   }
 
+  parsed_address <- addr_geocode_cli_suppress_warnings(
+    addr::as_addr(as.character(address))
+  )
+
   geocoded <- addr::geocode(
-    addr::as_addr(as.character(address)),
+    parsed_address,
     year = taf_year,
     progress = TRUE
   )

--- a/inst/exec/install-addr-taf-fuel.sh
+++ b/inst/exec/install-addr-taf-fuel.sh
@@ -1,42 +1,278 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ARCHIVE="${1:?usage: install-addr-taf-fuel.sh ARCHIVE.tar.zst [SHA256_FILE]}"
-SHA256_FILE="${2:-${ARCHIVE}.sha256}"
-YEAR="2025"
-VERSION="v1"
+usage() {
+  cat >&2 <<'EOF'
+usage: install-addr-taf-fuel.sh ARCHIVE.tar.zst [METADATA.json [ARCHIVE.tar.zst.sha256]]
+
+Installs packaged addr TAF fuel into tools::R_user_dir("addr", "data").
+Set R_USER_DATA_DIR before running this script to install somewhere else.
+The installer refuses to overwrite existing TAF fuel; delete existing year
+directories first if replacing an installed artifact.
+EOF
+}
+
+die() {
+  echo "install-addr-taf-fuel: $*" >&2
+  if [ -n "${README_FILE:-}" ]; then
+    echo "See the generated README sidecar for install and replacement details: ${README_FILE}" >&2
+  else
+    echo "See the generated .README.md sidecar for install and replacement details." >&2
+  fi
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+abs_path() {
+  local path="$1"
+  local dir
+  local base
+  dir="$(cd "$(dirname "$path")" && pwd)"
+  base="$(basename "$path")"
+  printf '%s/%s' "$dir" "$base"
+}
+
+json_get() {
+  local key="$1"
+  awk -v key="$key" '
+    $0 ~ "^[[:space:]]*\"" key "\"[[:space:]]*:" {
+      line = $0
+      sub("^[^\"]*\"" key "\"[[:space:]]*:[[:space:]]*", "", line)
+      if (line ~ /^"/) {
+        sub(/^"/, "", line)
+        sub(/"[[:space:]]*,?[[:space:]]*$/, "", line)
+      } else {
+        sub(/[[:space:]]*,?[[:space:]]*$/, "", line)
+      }
+      print line
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$JSON_FILE"
+}
+
+json_required() {
+  local key="$1"
+  local value
+  if ! value="$(json_get "$key")" || [ -z "$value" ]; then
+    die "metadata missing required field: ${key}"
+  fi
+  printf '%s' "$value"
+}
+
+validate_relative_path() {
+  local path="$1"
+  local label="$2"
+  local part
+  local trimmed="${path%/}"
+
+  [ -n "$trimmed" ] || die "${label} is empty"
+  case "$trimmed" in
+    /*) die "${label} must be relative: ${path}" ;;
+  esac
+
+  IFS='/' read -r -a parts <<< "$trimmed"
+  for part in "${parts[@]}"; do
+    if [ -z "$part" ] || [ "$part" = ".." ]; then
+      die "${label} contains an unsafe path segment: ${path}"
+    fi
+  done
+}
+
+validate_unsigned_integer() {
+  local value="$1"
+  local label="$2"
+  case "$value" in
+    ''|*[!0-9]*) die "${label} must be an unsigned integer: ${value}" ;;
+  esac
+}
+
+count_files() {
+  find "$1" -type f ! -name '.DS_Store' | wc -l | tr -d '[:space:]'
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+  usage
+  exit 1
+fi
+
+ARCHIVE="$1"
+DEFAULT_JSON="${ARCHIVE%.tar.zst}.json"
+DEFAULT_SHA256="${ARCHIVE}.sha256"
+
+if [ "$DEFAULT_JSON" = "$ARCHIVE" ]; then
+  die "archive must end in .tar.zst: ${ARCHIVE}"
+fi
+
+if [ "$#" -eq 2 ] && [ "${2##*.}" = "sha256" ]; then
+  JSON_FILE="$DEFAULT_JSON"
+  SHA256_FILE="$2"
+else
+  JSON_FILE="${2:-$DEFAULT_JSON}"
+  SHA256_FILE="${3:-$DEFAULT_SHA256}"
+fi
+
+README_FILE="${JSON_FILE%.json}.README.md"
+
+require_command Rscript
+require_command tar
+require_command zstd
+require_command shasum
+require_command find
+require_command wc
+require_command awk
+require_command mktemp
+
+[ -f "$ARCHIVE" ] || die "archive not found: ${ARCHIVE}"
+[ -f "$JSON_FILE" ] || die "metadata JSON not found: ${JSON_FILE}"
+[ -f "$SHA256_FILE" ] || die "sha256 file not found: ${SHA256_FILE}"
+
+ARCHIVE_ABS="$(abs_path "$ARCHIVE")"
+ARCHIVE_DIR="$(dirname "$ARCHIVE_ABS")"
+ARCHIVE_BASENAME="$(basename "$ARCHIVE_ABS")"
+JSON_FILE="$(abs_path "$JSON_FILE")"
+SHA256_FILE="$(abs_path "$SHA256_FILE")"
+README_FILE="$(abs_path "$README_FILE")"
+
+ARTIFACT_TYPE="$(json_required artifact_type)"
+SCHEMA_VERSION="$(json_required schema_version)"
+TAF_VERSION="$(json_required taf_version)"
+TAF_YEAR="$(json_required taf_year)"
+META_ARCHIVE_FILE="$(json_required archive_file)"
+META_ARCHIVE_SHA256="$(json_required archive_sha256)"
+META_ARCHIVE_SIZE_BYTES="$(json_required archive_size_bytes)"
+META_DATA_PATH="$(json_required data_path)"
+META_MANIFEST_PATH="$(json_required manifest_path)"
+META_REQUIRED_MANIFEST_FILE="$(json_required required_manifest_file)"
+META_DATA_FILE_COUNT="$(json_required data_file_count)"
+META_MANIFEST_FILE_COUNT="$(json_required manifest_file_count)"
+
+validate_unsigned_integer "$SCHEMA_VERSION" "metadata schema_version"
+validate_unsigned_integer "$META_ARCHIVE_SIZE_BYTES" "metadata archive_size_bytes"
+validate_unsigned_integer "$META_DATA_FILE_COUNT" "metadata data_file_count"
+validate_unsigned_integer "$META_MANIFEST_FILE_COUNT" "metadata manifest_file_count"
+
+[ "$ARTIFACT_TYPE" = "addr-taf-fuel" ] || die "unexpected artifact_type: ${ARTIFACT_TYPE}"
+[ "$SCHEMA_VERSION" = "1" ] || die "unsupported schema_version: ${SCHEMA_VERSION}"
+[ "$META_ARCHIVE_FILE" = "$ARCHIVE_BASENAME" ] || die "metadata archive_file does not match archive: ${META_ARCHIVE_FILE}"
+
+EXPECTED_DATA_PATH="${TAF_VERSION}/tiger_addr_feat/${TAF_YEAR}"
+EXPECTED_MANIFEST_PATH="${TAF_VERSION}/tiger_addr_feat_manifest/${TAF_YEAR}"
+EXPECTED_REQUIRED_MANIFEST_FILE="${EXPECTED_MANIFEST_PATH}/county_zip.parquet"
+
+[ "$META_DATA_PATH" = "$EXPECTED_DATA_PATH" ] || die "metadata data_path does not match taf version/year"
+[ "$META_MANIFEST_PATH" = "$EXPECTED_MANIFEST_PATH" ] || die "metadata manifest_path does not match taf version/year"
+[ "$META_REQUIRED_MANIFEST_FILE" = "$EXPECTED_REQUIRED_MANIFEST_FILE" ] || die "metadata required_manifest_file is not expected county_zip.parquet path"
+
+validate_relative_path "$META_DATA_PATH" "metadata data_path"
+validate_relative_path "$META_MANIFEST_PATH" "metadata manifest_path"
+validate_relative_path "$META_REQUIRED_MANIFEST_FILE" "metadata required_manifest_file"
+
+ACTUAL_ARCHIVE_SHA256="$(shasum -a 256 "$ARCHIVE_ABS" | awk '{print $1}')"
+[ "$ACTUAL_ARCHIVE_SHA256" = "$META_ARCHIVE_SHA256" ] || die "archive sha256 does not match metadata"
+
+ACTUAL_ARCHIVE_SIZE_BYTES="$(wc -c < "$ARCHIVE_ABS" | tr -d '[:space:]')"
+[ "$ACTUAL_ARCHIVE_SIZE_BYTES" = "$META_ARCHIVE_SIZE_BYTES" ] || die "archive size does not match metadata"
+
+(
+  cd "$ARCHIVE_DIR"
+  shasum -a 256 -c "$SHA256_FILE"
+) || die "sha256 validation failed"
 
 ADDR_DATA_DIR="$(Rscript -e 'cat(tools::R_user_dir("addr", "data"))')"
-TAF_DATA_DIR="${ADDR_DATA_DIR}/${VERSION}/tiger_addr_feat/${YEAR}"
-TAF_MANIFEST_DIR="${ADDR_DATA_DIR}/${VERSION}/tiger_addr_feat_manifest/${YEAR}"
-
-test -f "$ARCHIVE"
-test -f "$SHA256_FILE"
+TAF_DATA_DIR="${ADDR_DATA_DIR}/${META_DATA_PATH}"
+TAF_MANIFEST_DIR="${ADDR_DATA_DIR}/${META_MANIFEST_PATH}"
 
 existing_paths=()
 for path in "$TAF_DATA_DIR" "$TAF_MANIFEST_DIR"; do
-  if [ -e "$path" ]; then
+  if [ -e "$path" ] || [ -L "$path" ]; then
     existing_paths+=("$path")
   fi
 done
 
 if [ "${#existing_paths[@]}" -gt 0 ]; then
   {
-    echo "addr TAF fuel already exists at:"
+    echo "install-addr-taf-fuel: addr TAF fuel already exists at:"
     printf '  %s\n' "${existing_paths[@]}"
     echo
+    echo "The installer refuses to overwrite existing TAF fuel."
     echo "Delete the existing path(s) first, then rerun this script."
+    echo "To install somewhere else, set R_USER_DATA_DIR before running this script."
+    echo "See the generated README sidecar for details: ${README_FILE}"
   } >&2
   exit 1
 fi
 
-shasum -a 256 -c "$SHA256_FILE"
+STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/addr-taf-install.XXXXXX")"
+cleanup() {
+  rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
 
-mkdir -p "$ADDR_DATA_DIR"
+MEMBERS_FILE="${STAGING_DIR}/archive-members.txt"
+zstd -dc "$ARCHIVE_ABS" | tar -tf - > "$MEMBERS_FILE"
 
-zstd -dc "$ARCHIVE" | tar -C "$ADDR_DATA_DIR" -xf -
+while IFS= read -r member; do
+  member="${member%/}"
+  validate_relative_path "$member" "archive member"
+  case "$member" in
+    "$META_DATA_PATH"|"$META_DATA_PATH"/*|"$META_MANIFEST_PATH"|"$META_MANIFEST_PATH"/*)
+      ;;
+    *)
+      die "archive contains unexpected member: ${member}"
+      ;;
+  esac
+done < "$MEMBERS_FILE"
+
+zstd -dc "$ARCHIVE_ABS" | tar -C "$STAGING_DIR" -xf -
+
+STAGED_DATA_DIR="${STAGING_DIR}/${META_DATA_PATH}"
+STAGED_MANIFEST_DIR="${STAGING_DIR}/${META_MANIFEST_PATH}"
+STAGED_REQUIRED_MANIFEST_FILE="${STAGING_DIR}/${META_REQUIRED_MANIFEST_FILE}"
+
+[ -d "$STAGED_DATA_DIR" ] || die "staged data directory missing: ${META_DATA_PATH}"
+[ -d "$STAGED_MANIFEST_DIR" ] || die "staged manifest directory missing: ${META_MANIFEST_PATH}"
+[ -f "$STAGED_REQUIRED_MANIFEST_FILE" ] || die "staged required manifest file missing: ${META_REQUIRED_MANIFEST_FILE}"
+
+STAGED_DATA_FILE_COUNT="$(count_files "$STAGED_DATA_DIR")"
+STAGED_MANIFEST_FILE_COUNT="$(count_files "$STAGED_MANIFEST_DIR")"
+
+[ "$STAGED_DATA_FILE_COUNT" = "$META_DATA_FILE_COUNT" ] || die "staged data file count does not match metadata"
+[ "$STAGED_MANIFEST_FILE_COUNT" = "$META_MANIFEST_FILE_COUNT" ] || die "staged manifest file count does not match metadata"
+
+mkdir -p "$(dirname "$TAF_DATA_DIR")"
+mkdir -p "$(dirname "$TAF_MANIFEST_DIR")"
+
+mv "$STAGED_DATA_DIR" "$TAF_DATA_DIR"
+mv "$STAGED_MANIFEST_DIR" "$TAF_MANIFEST_DIR"
 
 echo "installed addr TAF fuel under: $ADDR_DATA_DIR"
+echo "installed data: $TAF_DATA_DIR"
+echo "installed manifest: $TAF_MANIFEST_DIR"
 
-Rscript -e 'stopifnot(nrow(addr::taf_zip("45220", year = "2025")) > 0); message("taf_zip verification passed")'
-Rscript -e 'addr::geocode(addr::as_addr("3333 Burnet Ave Cincinnati OH 45229"), year = "2025", taf_install = FALSE); message("geocode verification passed")'
+ADDR_TAF_YEAR="$TAF_YEAR" ADDR_TAF_VERSION="$TAF_VERSION" Rscript -e '
+year <- Sys.getenv("ADDR_TAF_YEAR")
+version <- Sys.getenv("ADDR_TAF_VERSION")
+stopifnot(nrow(addr::taf_zip("45220", year = year, version = version)) > 0)
+message("taf_zip verification passed")
+'
+
+ADDR_TAF_YEAR="$TAF_YEAR" ADDR_TAF_VERSION="$TAF_VERSION" Rscript -e '
+year <- Sys.getenv("ADDR_TAF_YEAR")
+version <- Sys.getenv("ADDR_TAF_VERSION")
+addr::geocode(
+  addr::as_addr("3333 Burnet Ave Cincinnati OH 45229"),
+  year = year,
+  version = version,
+  taf_install = FALSE
+)
+message("geocode verification passed")
+'

--- a/inst/exec/install-addr-taf-fuel.sh
+++ b/inst/exec/install-addr-taf-fuel.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCHIVE="${1:?usage: install-addr-taf-fuel.sh ARCHIVE.tar.zst [SHA256_FILE]}"
+SHA256_FILE="${2:-${ARCHIVE}.sha256}"
+
+ADDR_DATA_DIR="$(Rscript -e 'cat(tools::R_user_dir("addr", "data"))')"
+
+test -f "$ARCHIVE"
+test -f "$SHA256_FILE"
+
+shasum -a 256 -c "$SHA256_FILE"
+
+mkdir -p "$ADDR_DATA_DIR"
+
+zstd -dc "$ARCHIVE" | tar -C "$ADDR_DATA_DIR" -xf -
+
+echo "installed addr TAF fuel under: $ADDR_DATA_DIR"
+
+Rscript -e 'stopifnot(nrow(addr::taf_zip("45220", year = "2025")) > 0); message("taf_zip verification passed")'
+Rscript -e 'addr::geocode(addr::as_addr("3333 Burnet Ave Cincinnati OH 45229"), year = "2025", taf_install = FALSE); message("geocode verification passed")'

--- a/inst/exec/install-addr-taf-fuel.sh
+++ b/inst/exec/install-addr-taf-fuel.sh
@@ -3,11 +3,32 @@ set -euo pipefail
 
 ARCHIVE="${1:?usage: install-addr-taf-fuel.sh ARCHIVE.tar.zst [SHA256_FILE]}"
 SHA256_FILE="${2:-${ARCHIVE}.sha256}"
+YEAR="2025"
+VERSION="v1"
 
 ADDR_DATA_DIR="$(Rscript -e 'cat(tools::R_user_dir("addr", "data"))')"
+TAF_DATA_DIR="${ADDR_DATA_DIR}/${VERSION}/tiger_addr_feat/${YEAR}"
+TAF_MANIFEST_DIR="${ADDR_DATA_DIR}/${VERSION}/tiger_addr_feat_manifest/${YEAR}"
 
 test -f "$ARCHIVE"
 test -f "$SHA256_FILE"
+
+existing_paths=()
+for path in "$TAF_DATA_DIR" "$TAF_MANIFEST_DIR"; do
+  if [ -e "$path" ]; then
+    existing_paths+=("$path")
+  fi
+done
+
+if [ "${#existing_paths[@]}" -gt 0 ]; then
+  {
+    echo "addr TAF fuel already exists at:"
+    printf '  %s\n' "${existing_paths[@]}"
+    echo
+    echo "Delete the existing path(s) first, then rerun this script."
+  } >&2
+  exit 1
+fi
 
 shasum -a 256 -c "$SHA256_FILE"
 

--- a/inst/exec/pack-addr-taf-fuel.sh
+++ b/inst/exec/pack-addr-taf-fuel.sh
@@ -4,30 +4,220 @@ set -euo pipefail
 YEAR="${1:-2025}"
 VERSION="${2:-v1}"
 OUT_DIR="${3:-$PWD}"
-ARCHIVE="addr-taf-${VERSION}-${YEAR}.tar.zst"
+BASE="addr-taf-${VERSION}-${YEAR}"
+ARCHIVE="${BASE}.tar.zst"
+SHA256_FILE="${ARCHIVE}.sha256"
+JSON_FILE="${BASE}.json"
+README_FILE="${BASE}.README.md"
+
+die() {
+  echo "pack-addr-taf-fuel: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '%s' "$value"
+}
+
+json_string_field() {
+  local key="$1"
+  local value="$2"
+  local comma=","
+  if [ "$#" -ge 3 ]; then
+    comma="$3"
+  fi
+  printf '  "%s": "%s"%s\n' "$key" "$(json_escape "$value")" "$comma"
+}
+
+json_number_field() {
+  local key="$1"
+  local value="$2"
+  local comma=","
+  if [ "$#" -ge 3 ]; then
+    comma="$3"
+  fi
+  printf '  "%s": %s%s\n' "$key" "$value" "$comma"
+}
+
+count_files() {
+  find "$1" -type f ! -name '.DS_Store' | wc -l | tr -d '[:space:]'
+}
+
+require_command Rscript
+require_command tar
+require_command zstd
+require_command shasum
+require_command find
+require_command wc
+require_command awk
+require_command date
+
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+
+for output in "$ARCHIVE" "$SHA256_FILE" "$JSON_FILE" "$README_FILE"; do
+  if [ -e "${OUT_DIR}/${output}" ] || [ -L "${OUT_DIR}/${output}" ]; then
+    die "output already exists: ${OUT_DIR}/${output}"
+  fi
+done
 
 ADDR_DATA_DIR="$(Rscript -e 'cat(tools::R_user_dir("addr", "data"))')"
+ADDR_PACKAGE_VERSION="$(
+  Rscript -e '
+version <- tryCatch(
+  as.character(utils::packageVersion("addr")),
+  error = function(e) NA_character_
+)
+if (is.na(version) && file.exists("DESCRIPTION")) {
+  version <- read.dcf("DESCRIPTION")[1, "Version"]
+}
+if (is.na(version)) {
+  stop("could not determine addr package version", call. = FALSE)
+}
+cat(version)
+'
+)"
+
+DATA_PATH="${VERSION}/tiger_addr_feat/${YEAR}"
+MANIFEST_PATH="${VERSION}/tiger_addr_feat_manifest/${YEAR}"
+REQUIRED_MANIFEST_FILE="${MANIFEST_PATH}/county_zip.parquet"
 
 cd "$ADDR_DATA_DIR"
 
-test -d "${VERSION}/tiger_addr_feat/${YEAR}"
-test -f "${VERSION}/tiger_addr_feat_manifest/${YEAR}/county_zip.parquet"
+[ -d "$DATA_PATH" ] || die "missing TAF data directory: ${ADDR_DATA_DIR}/${DATA_PATH}"
+[ -d "$MANIFEST_PATH" ] || die "missing TAF manifest directory: ${ADDR_DATA_DIR}/${MANIFEST_PATH}"
+[ -f "$REQUIRED_MANIFEST_FILE" ] || die "missing required manifest file: ${ADDR_DATA_DIR}/${REQUIRED_MANIFEST_FILE}"
 
-mkdir -p "$OUT_DIR"
+DATA_FILE_COUNT="$(count_files "$DATA_PATH")"
+MANIFEST_FILE_COUNT="$(count_files "$MANIFEST_PATH")"
 
-# TODO: If final archives are produced on macOS, suppress Apple extended
-# metadata such as LIBARCHIVE.xattr.com.apple.provenance so GNU tar users do
-# not see unknown extended header warnings during extraction.
-tar \
+TMP_DIR="$(mktemp -d "${OUT_DIR}/.addr-taf-pack.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+COPYFILE_DISABLE=1 tar \
+  --no-xattrs \
   --exclude='.DS_Store' \
   --exclude='*/tiger_addr_feat_locks/*' \
   -cf - \
-  "${VERSION}/tiger_addr_feat/${YEAR}" \
-  "${VERSION}/tiger_addr_feat_manifest/${YEAR}" \
-  | zstd -T0 -19 -o "${OUT_DIR}/${ARCHIVE}"
+  "$DATA_PATH" \
+  "$MANIFEST_PATH" \
+  | zstd -T0 -19 -o "${TMP_DIR}/${ARCHIVE}"
 
-cd "$OUT_DIR"
-shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+(
+  cd "$TMP_DIR"
+  shasum -a 256 "$ARCHIVE" > "$SHA256_FILE"
+)
+
+ARCHIVE_SHA256="$(awk '{print $1}' "${TMP_DIR}/${SHA256_FILE}")"
+ARCHIVE_SIZE_BYTES="$(wc -c < "${TMP_DIR}/${ARCHIVE}" | tr -d '[:space:]')"
+CREATED_UTC="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+{
+  printf '{\n'
+  json_string_field "artifact_type" "addr-taf-fuel"
+  json_number_field "schema_version" "1"
+  json_string_field "taf_version" "$VERSION"
+  json_string_field "taf_year" "$YEAR"
+  json_string_field "addr_package_version" "$ADDR_PACKAGE_VERSION"
+  json_string_field "archive_file" "$ARCHIVE"
+  json_string_field "archive_sha256" "$ARCHIVE_SHA256"
+  json_number_field "archive_size_bytes" "$ARCHIVE_SIZE_BYTES"
+  json_string_field "created_utc" "$CREATED_UTC"
+  json_string_field "data_path" "$DATA_PATH"
+  json_string_field "manifest_path" "$MANIFEST_PATH"
+  json_string_field "required_manifest_file" "$REQUIRED_MANIFEST_FILE"
+  json_number_field "data_file_count" "$DATA_FILE_COUNT"
+  json_number_field "manifest_file_count" "$MANIFEST_FILE_COUNT" ""
+  printf '}\n'
+} > "${TMP_DIR}/${JSON_FILE}"
+
+cat > "${TMP_DIR}/${README_FILE}" <<EOF
+# addr TAF fuel artifact
+
+This artifact contains installed addr TIGER address feature data for:
+
+- TAF version: ${VERSION}
+- TAF year: ${YEAR}
+- addr package version used to package it: ${ADDR_PACKAGE_VERSION}
+- archive: ${ARCHIVE}
+- sha256: ${ARCHIVE_SHA256}
+
+## Install
+
+Run the installer from a shell, not from inside R.
+
+From a source checkout:
+
+\`\`\`sh
+inst/exec/install-addr-taf-fuel.sh ${ARCHIVE}
+\`\`\`
+
+From an installed addr package:
+
+\`\`\`sh
+Rscript "\$(Rscript -e 'cat(system.file("exec", "install-addr-taf-fuel.sh", package = "addr"))')" \\
+  ${ARCHIVE}
+\`\`\`
+
+By default, the installer writes to the directory returned by:
+
+\`\`\`sh
+Rscript -e 'cat(tools::R_user_dir("addr", "data"))'
+\`\`\`
+
+To install somewhere else, set R_USER_DATA_DIR before running the installer:
+
+\`\`\`sh
+export R_USER_DATA_DIR=/scratch/<user>/addr-data
+inst/exec/install-addr-taf-fuel.sh ${ARCHIVE}
+\`\`\`
+
+With standard R user-directory behavior, that installs under:
+
+\`\`\`text
+\${R_USER_DATA_DIR}/R/addr/${VERSION}/tiger_addr_feat/${YEAR}
+\${R_USER_DATA_DIR}/R/addr/${VERSION}/tiger_addr_feat_manifest/${YEAR}
+\`\`\`
+
+## Replacement behavior
+
+The installer refuses to overwrite existing TAF fuel. If either target year
+directory already exists, delete the existing directories first, then rerun the
+installer.
+
+For this artifact, the target directories are:
+
+\`\`\`text
+${VERSION}/tiger_addr_feat/${YEAR}
+${VERSION}/tiger_addr_feat_manifest/${YEAR}
+\`\`\`
+
+The installer validates the archive checksum and metadata before installing.
+Keep the .tar.zst, .tar.zst.sha256, .json, and this README file together.
+EOF
+
+mv "${TMP_DIR}/${ARCHIVE}" "${OUT_DIR}/${ARCHIVE}"
+mv "${TMP_DIR}/${SHA256_FILE}" "${OUT_DIR}/${SHA256_FILE}"
+mv "${TMP_DIR}/${JSON_FILE}" "${OUT_DIR}/${JSON_FILE}"
+mv "${TMP_DIR}/${README_FILE}" "${OUT_DIR}/${README_FILE}"
+
+trap - EXIT
+rmdir "$TMP_DIR"
 
 echo "wrote: ${OUT_DIR}/${ARCHIVE}"
-echo "wrote: ${OUT_DIR}/${ARCHIVE}.sha256"
+echo "wrote: ${OUT_DIR}/${SHA256_FILE}"
+echo "wrote: ${OUT_DIR}/${JSON_FILE}"
+echo "wrote: ${OUT_DIR}/${README_FILE}"

--- a/inst/exec/pack-addr-taf-fuel.sh
+++ b/inst/exec/pack-addr-taf-fuel.sh
@@ -15,6 +15,9 @@ test -f "${VERSION}/tiger_addr_feat_manifest/${YEAR}/county_zip.parquet"
 
 mkdir -p "$OUT_DIR"
 
+# TODO: If final archives are produced on macOS, suppress Apple extended
+# metadata such as LIBARCHIVE.xattr.com.apple.provenance so GNU tar users do
+# not see unknown extended header warnings during extraction.
 tar \
   --exclude='.DS_Store' \
   --exclude='*/tiger_addr_feat_locks/*' \

--- a/inst/exec/pack-addr-taf-fuel.sh
+++ b/inst/exec/pack-addr-taf-fuel.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+YEAR="${1:-2025}"
+VERSION="${2:-v1}"
+OUT_DIR="${3:-$PWD}"
+ARCHIVE="addr-taf-${VERSION}-${YEAR}.tar.zst"
+
+ADDR_DATA_DIR="$(Rscript -e 'cat(tools::R_user_dir("addr", "data"))')"
+
+cd "$ADDR_DATA_DIR"
+
+test -d "${VERSION}/tiger_addr_feat/${YEAR}"
+test -f "${VERSION}/tiger_addr_feat_manifest/${YEAR}/county_zip.parquet"
+
+mkdir -p "$OUT_DIR"
+
+tar \
+  --exclude='.DS_Store' \
+  --exclude='*/tiger_addr_feat_locks/*' \
+  -cf - \
+  "${VERSION}/tiger_addr_feat/${YEAR}" \
+  "${VERSION}/tiger_addr_feat_manifest/${YEAR}" \
+  | zstd -T0 -19 -o "${OUT_DIR}/${ARCHIVE}"
+
+cd "$OUT_DIR"
+shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+
+echo "wrote: ${OUT_DIR}/${ARCHIVE}"
+echo "wrote: ${OUT_DIR}/${ARCHIVE}.sha256"


### PR DESCRIPTION
- add `addr-geocode` as an installed command-line entrypoint for csv and parquet address files with a required `address` column
- link the entrypoint into the container image and document versioned docker/apptainer usage with scratch-backed data and temp mounts
- add deterministic output naming based on the installed `addr` version and matching input/output file types
- keep command-line and container checks outside the package test suite in `cli-tests/` with `just` targets for local and container smoke testing