### PR TITLE
guard live tiger download tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
 
     env:
+      ADDR_RUN_NETWORK_TESTS: "false"
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       R_MAX_PROTECT_SIZE: 500000

--- a/.github/workflows/network-tests.yaml
+++ b/.github/workflows/network-tests.yaml
@@ -1,0 +1,35 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * 1"
+
+name: live-tiger-download-tests
+
+concurrency:
+  group: live-tiger-download-tests
+  cancel-in-progress: false
+
+jobs:
+  live-tiger-download-tests:
+    runs-on: ubuntu-latest
+
+    env:
+      ADDR_RUN_NETWORK_TESTS: "true"
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      R_MAX_PROTECT_SIZE: 500000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: test
+
+      - name: Run TIGER network smoke tests
+        run: Rscript -e 'testthat::test_local(filter = "tiger")'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CRAN
 status](https://www.r-pkg.org/badges/version/addr)](https://CRAN.R-project.org/package=addr)
 [![R-CMD-check](https://github.com/geomarker-io/addr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/geomarker-io/addr/actions/workflows/R-CMD-check.yaml)
+[![live TIGER download tests](https://github.com/geomarker-io/addr/actions/workflows/network-tests.yaml/badge.svg?branch=main)](https://github.com/geomarker-io/addr/actions/workflows/network-tests.yaml)
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![r-universe](https://geomarker-io.r-universe.dev/badges/addr)](https://geomarker-io.r-universe.dev/addr)

--- a/tests/testthat/helper-network.R
+++ b/tests/testthat/helper-network.R
@@ -1,0 +1,13 @@
+addr_run_network_tests <- function() {
+  tolower(Sys.getenv("ADDR_RUN_NETWORK_TESTS", unset = "")) %in%
+    c("1", "true", "yes")
+}
+
+skip_live_tiger_downloads <- function() {
+  testthat::skip_if_not(
+    addr_run_network_tests(),
+    "live TIGER download tests are disabled"
+  )
+  testthat::skip_if_offline()
+  testthat::skip_on_cran()
+}

--- a/tests/testthat/test-tiger.R
+++ b/tests/testthat/test-tiger.R
@@ -1,6 +1,5 @@
 test_that("can download files from tiger", {
-  skip_if_offline()
-  skip_on_cran()
+  skip_live_tiger_downloads()
   withr::local_envvar(list("R_USER_DATA_DIR" = tempfile()))
   dl_file <- tiger_download(
     "TIGER2024/FEATNAMES/tl_2024_39061_featnames.zip"
@@ -122,8 +121,7 @@ test_that("tiger_download reuses cached files without downloading", {
 })
 
 test_that("tiger_addr_feat() can download addr feat from tiger", {
-  skip_if_offline()
-  skip_on_cran()
+  skip_live_tiger_downloads()
   skip_on_ci()
   withr::local_envvar(list("R_USER_DATA_DIR" = tempfile()))
   d <- tiger_addr_feat(county = "39061", year = "2024")
@@ -267,8 +265,7 @@ test_that("taf_ensure installs only missing needed counties", {
 })
 
 test_that("tiger_addr_feat() works with existing user data dir", {
-  skip_if_offline()
-  skip_on_cran()
+  skip_live_tiger_downloads()
   skip_on_ci()
   d <- tiger_addr_feat(county = "39061", year = "2024")
   expect_s3_class(d, c("sf", "tbl_df", "tbl", "data.frame"))


### PR DESCRIPTION
- skip live TIGER download tests by default unless `ADDR_RUN_NETWORK_TESTS` is explicitly enabled
- keep the normal three-platform `R-CMD-check` matrix from hitting the Census TIGER endpoint
- add a serialized Ubuntu-only live TIGER smoke workflow for manual and scheduled runs
- keep heavier `tiger_addr_feat()` download/parsing checks out of CI while preserving local opt-in behavior